### PR TITLE
Create TochkaRosta Flutter skeleton

### DIFF
--- a/assets/translations/intl_en.arb
+++ b/assets/translations/intl_en.arb
@@ -1,0 +1,12 @@
+{
+  "@@locale": "en",
+  "appTitle": "Tochka Rosta",
+  "onboardingTitle": "Welcome",
+  "authTitle": "Sign In",
+  "homeTitle": "Home",
+  "surveyTitle": "Survey",
+  "resultsTitle": "Results",
+  "chatTitle": "Chat",
+  "profileTitle": "Profile",
+  "settingsTitle": "Settings"
+}

--- a/assets/translations/intl_ru.arb
+++ b/assets/translations/intl_ru.arb
@@ -1,0 +1,12 @@
+{
+  "@@locale": "ru",
+  "appTitle": "Точка Роста",
+  "onboardingTitle": "Добро пожаловать",
+  "authTitle": "Авторизация",
+  "homeTitle": "Главная",
+  "surveyTitle": "Опрос",
+  "resultsTitle": "Результаты",
+  "chatTitle": "Чат",
+  "profileTitle": "Профиль",
+  "settingsTitle": "Настройки"
+}

--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -1,0 +1,31 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+part 'app_database.g.dart';
+
+class SurveyEntries extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get title => text()();
+  TextColumn get description => text().nullable()();
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+}
+
+@DriftDatabase(tables: [SurveyEntries])
+class AppDatabase extends _$AppDatabase {
+  AppDatabase() : super(_openConnection());
+
+  @override
+  int get schemaVersion => 1;
+}
+
+LazyDatabase _openConnection() {
+  return LazyDatabase(() async {
+    final dbFolder = await getApplicationDocumentsDirectory();
+    final file = File(p.join(dbFolder.path, 'tochka_rosta.db'));
+    return NativeDatabase.createInBackground(file);
+  });
+}

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -1,0 +1,38 @@
+// GENERATED CODE - PLACEHOLDER FOR DRIFT BUILDERS
+// ignore_for_file: type=lint
+part of 'app_database.dart';
+
+abstract class _$AppDatabase extends GeneratedDatabase {
+  _$AppDatabase(QueryExecutor e) : super(e);
+
+  late final $SurveyEntriesTable surveyEntries = $SurveyEntriesTable(this);
+
+  @override
+  Iterable<TableInfo<Table, Object?>> get allTables => [surveyEntries];
+}
+
+class $SurveyEntriesTable extends SurveyEntries with TableInfo<$SurveyEntriesTable, SurveyEntry> {
+  $SurveyEntriesTable(this.attachedDatabase);
+
+  final GeneratedDatabase attachedDatabase;
+
+  @override
+  SurveyEntry map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return SurveyEntry(
+      id: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      title: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}title'])!,
+      description: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}description']),
+      createdAt: attachedDatabase.typeMapping.read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
+    );
+  }
+}
+
+class SurveyEntry {
+  const SurveyEntry({required this.id, required this.title, this.description, required this.createdAt});
+
+  final int id;
+  final String title;
+  final String? description;
+  final DateTime createdAt;
+}

--- a/lib/core/localization/l10n.dart
+++ b/lib/core/localization/l10n.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart';
+
+class AppLocalizations {
+  AppLocalizations(this.locale);
+
+  final Locale locale;
+
+  static const defaultTitle = 'TochkaRosta';
+
+  static const localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+  ];
+
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+
+  static const supportedLocales = <Locale>[
+    Locale('ru'),
+    Locale('en'),
+  ];
+
+  static Future<AppLocalizations> load(Locale locale) async {
+    final canonicalLocale = Intl.canonicalizedLocale(locale.toString());
+    final parts = canonicalLocale.split('_');
+    final normalizedLocale = Locale(parts.first, parts.length > 1 ? parts[1] : null);
+    final localization = AppLocalizations(normalizedLocale);
+    await localization._loadTranslations();
+    return localization;
+  }
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations) ?? AppLocalizations(const Locale('ru'));
+  }
+
+  late Map<String, String> _localizedStrings;
+
+  Future<void> _loadTranslations() async {
+    final fallbacks = <String>{locale.languageCode, 'ru'};
+    for (final code in fallbacks) {
+      try {
+        final jsonString = await rootBundle.loadString('assets/translations/intl_${code.toLowerCase()}.arb');
+        final Map<String, dynamic> jsonMap = json.decode(jsonString) as Map<String, dynamic>;
+        _localizedStrings = jsonMap.map((key, value) => MapEntry(key, value.toString()));
+        return;
+      } catch (_) {
+        continue;
+      }
+    }
+    _localizedStrings = {'appTitle': defaultTitle};
+  }
+
+  String _get(String key) {
+    return _localizedStrings[key] ?? _localizedStrings['appTitle'] ?? defaultTitle;
+  }
+
+  String get appTitle => _get('appTitle');
+  String get onboardingTitle => _get('onboardingTitle');
+  String get authTitle => _get('authTitle');
+  String get homeTitle => _get('homeTitle');
+  String get surveyTitle => _get('surveyTitle');
+  String get resultsTitle => _get('resultsTitle');
+  String get chatTitle => _get('chatTitle');
+  String get profileTitle => _get('profileTitle');
+  String get settingsTitle => _get('settingsTitle');
+}
+
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => AppLocalizations.supportedLocales.any((supported) => supported.languageCode == locale.languageCode);
+
+  @override
+  Future<AppLocalizations> load(Locale locale) => AppLocalizations.load(locale);
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}

--- a/lib/core/network/interceptors/jwt_interceptor.dart
+++ b/lib/core/network/interceptors/jwt_interceptor.dart
@@ -1,0 +1,42 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/app_providers.dart';
+
+class JwtInterceptor extends Interceptor {
+  JwtInterceptor(this.ref);
+
+  final Ref ref;
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    final token = ref.read(authTokenProvider);
+    if (token != null) {
+      options.headers['Authorization'] = 'Bearer $token';
+    }
+    super.onRequest(options, handler);
+  }
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) async {
+    if (err.response?.statusCode == 401) {
+      final refreshed = await _refreshToken();
+      if (refreshed) {
+        final requestOptions = err.requestOptions;
+        final dio = ref.read(dioProvider);
+        final response = await dio.fetch(requestOptions);
+        return handler.resolve(response);
+      }
+    }
+    super.onError(err, handler);
+  }
+
+  Future<bool> _refreshToken() async {
+    final refreshToken = ref.read(refreshTokenProvider);
+    if (refreshToken == null) {
+      return false;
+    }
+    // TODO: Implement refresh flow using Dio once backend is available.
+    return false;
+  }
+}

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -1,0 +1,32 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../database/app_database.dart';
+import '../network/interceptors/jwt_interceptor.dart';
+
+final themeModeProvider = StateProvider<ThemeMode>((ref) => ThemeMode.system);
+
+final textScaleFactorProvider = StateProvider<double>((ref) => 1.0);
+
+final localeProvider = StateProvider<Locale>((ref) => const Locale('ru'));
+
+final appDatabaseProvider = Provider<AppDatabase>((ref) {
+  final database = AppDatabase();
+  ref.onDispose(database.close);
+  return database;
+});
+
+final dioProvider = Provider<Dio>((ref) {
+  final dio = Dio(
+    BaseOptions(
+      connectTimeout: const Duration(seconds: 10),
+      receiveTimeout: const Duration(seconds: 10),
+    ),
+  );
+  dio.interceptors.add(JwtInterceptor(ref));
+  return dio;
+});
+
+final authTokenProvider = StateProvider<String?>((ref) => null);
+final refreshTokenProvider = StateProvider<String?>((ref) => null);

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../localization/l10n.dart';
+import '../../features/auth/presentation/pages/auth_page.dart';
+import '../../features/chat/presentation/pages/chat_page.dart';
+import '../../features/home/presentation/pages/home_page.dart';
+import '../../features/onboarding/presentation/pages/onboarding_page.dart';
+import '../../features/profile/presentation/pages/profile_page.dart';
+import '../../features/results/presentation/pages/results_page.dart';
+import '../../features/settings/presentation/pages/settings_page.dart';
+import '../../features/survey/presentation/pages/survey_page.dart';
+
+final appRouterProvider = Provider<GoRouter>((ref) {
+  return GoRouter(
+    initialLocation: OnboardingPage.routePath,
+    routes: [
+      GoRoute(
+        path: OnboardingPage.routePath,
+        name: OnboardingPage.routeName,
+        builder: (context, state) => const OnboardingPage(),
+      ),
+      GoRoute(
+        path: AuthPage.routePath,
+        name: AuthPage.routeName,
+        builder: (context, state) => const AuthPage(),
+      ),
+      StatefulShellRoute.indexedStack(
+        builder: (context, state, navigationShell) => AppShell(shell: navigationShell),
+        branches: [
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: HomePage.routePath,
+                name: HomePage.routeName,
+                builder: (context, state) => const HomePage(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: SurveyPage.routePath,
+                name: SurveyPage.routeName,
+                builder: (context, state) => const SurveyPage(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: ResultsPage.routePath,
+                name: ResultsPage.routeName,
+                builder: (context, state) => const ResultsPage(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: ChatPage.routePath,
+                name: ChatPage.routeName,
+                builder: (context, state) => const ChatPage(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: ProfilePage.routePath,
+                name: ProfilePage.routeName,
+                builder: (context, state) => const ProfilePage(),
+                routes: [
+                  GoRoute(
+                    path: SettingsPage.routePath,
+                    name: SettingsPage.routeName,
+                    builder: (context, state) => const SettingsPage(),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  );
+});
+
+class AppShell extends StatelessWidget {
+  const AppShell({super.key, required this.shell});
+
+  final StatefulNavigationShell shell;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Scaffold(
+      body: shell,
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: shell.currentIndex,
+        onDestinationSelected: shell.goBranch,
+        destinations: [
+          NavigationDestination(icon: const Icon(Icons.home_outlined), label: l10n.homeTitle),
+          NavigationDestination(icon: const Icon(Icons.assignment_outlined), label: l10n.surveyTitle),
+          NavigationDestination(icon: const Icon(Icons.insights_outlined), label: l10n.resultsTitle),
+          NavigationDestination(icon: const Icon(Icons.chat_bubble_outline), label: l10n.chatTitle),
+          NavigationDestination(icon: const Icon(Icons.person_outline), label: l10n.profileTitle),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class AppTheme {
+  static final light = ThemeData(
+    brightness: Brightness.light,
+    colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF0057FF)),
+    useMaterial3: true,
+    inputDecorationTheme: const InputDecorationTheme(
+      border: OutlineInputBorder(),
+    ),
+  );
+
+  static final dark = ThemeData(
+    brightness: Brightness.dark,
+    colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF7AA2FF), brightness: Brightness.dark),
+    useMaterial3: true,
+    inputDecorationTheme: const InputDecorationTheme(
+      border: OutlineInputBorder(),
+    ),
+  );
+}

--- a/lib/core/widgets/app_primary_button.dart
+++ b/lib/core/widgets/app_primary_button.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class AppPrimaryButton extends StatelessWidget {
+  const AppPrimaryButton({super.key, required this.onPressed, required this.label});
+
+  final VoidCallback onPressed;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        onPressed: onPressed,
+        child: Text(label),
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/app_text_field.dart
+++ b/lib/core/widgets/app_text_field.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class AppTextField extends StatelessWidget {
+  const AppTextField({
+    super.key,
+    this.controller,
+    this.label,
+    this.obscureText = false,
+    this.keyboardType,
+  });
+
+  final TextEditingController? controller;
+  final String? label;
+  final bool obscureText;
+  final TextInputType? keyboardType;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      obscureText: obscureText,
+      keyboardType: keyboardType,
+      decoration: InputDecoration(labelText: label),
+    );
+  }
+}

--- a/lib/features/auth/presentation/pages/auth_page.dart
+++ b/lib/features/auth/presentation/pages/auth_page.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/localization/l10n.dart';
+import '../../../../core/widgets/app_primary_button.dart';
+import '../../../../core/widgets/app_text_field.dart';
+import '../../../home/presentation/pages/home_page.dart';
+
+class AuthPage extends ConsumerWidget {
+  const AuthPage({super.key});
+
+  static const routeName = 'auth';
+  static const routePath = '/auth';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.authTitle)),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            AppTextField(label: 'Email', keyboardType: TextInputType.emailAddress),
+            const SizedBox(height: 16),
+            const AppTextField(label: 'Пароль', obscureText: true),
+            const SizedBox(height: 24),
+            AppPrimaryButton(
+              onPressed: () => context.go(HomePage.routePath),
+              label: 'Войти',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/chat/presentation/pages/chat_page.dart
+++ b/lib/features/chat/presentation/pages/chat_page.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/localization/l10n.dart';
+
+class ChatPage extends StatelessWidget {
+  const ChatPage({super.key});
+
+  static const routeName = 'chat';
+  static const routePath = '/chat';
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.chatTitle)),
+      body: const Center(
+        child: Text('Коммуникации с наставниками появятся в этом разделе.'),
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/pages/home_page.dart
+++ b/lib/features/home/presentation/pages/home_page.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/localization/l10n.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  static const routeName = 'home';
+  static const routePath = '/home';
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.homeTitle)),
+      body: const Center(
+        child: Text('Контент главной страницы появится позже.'),
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/data/onboarding_local_datasource.dart
+++ b/lib/features/onboarding/data/onboarding_local_datasource.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class OnboardingLocalDataSource {
+  const OnboardingLocalDataSource();
+
+  Future<void> cacheOnboardingComplete() async {
+    // TODO: Persist onboarding completion flag locally.
+  }
+}
+
+final onboardingLocalDataSourceProvider = Provider<OnboardingLocalDataSource>((ref) {
+  return const OnboardingLocalDataSource();
+});

--- a/lib/features/onboarding/domain/onboarding_repository.dart
+++ b/lib/features/onboarding/domain/onboarding_repository.dart
@@ -1,0 +1,3 @@
+abstract class OnboardingRepository {
+  Future<void> completeOnboarding();
+}

--- a/lib/features/onboarding/presentation/pages/onboarding_page.dart
+++ b/lib/features/onboarding/presentation/pages/onboarding_page.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/localization/l10n.dart';
+import '../../../auth/presentation/pages/auth_page.dart';
+import '../providers/onboarding_providers.dart';
+
+class OnboardingPage extends ConsumerWidget {
+  const OnboardingPage({super.key});
+
+  static const routeName = 'onboarding';
+  static const routePath = '/onboarding';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.onboardingTitle)),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l10n.onboardingTitle,
+              style: Theme.of(context).textTheme.headlineLarge,
+            ),
+            const SizedBox(height: 16),
+            Text('Здесь появится краткое описание приложения TochkaRosta и его возможностей.'),
+            const Spacer(),
+            FilledButton(
+              onPressed: () async {
+                await ref.read(onboardingCompletionController.future);
+                if (context.mounted) {
+                  context.go(AuthPage.routePath);
+                }
+              },
+              child: const Text('Продолжить'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/presentation/providers/onboarding_providers.dart
+++ b/lib/features/onboarding/presentation/providers/onboarding_providers.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/onboarding_local_datasource.dart';
+import '../../domain/onboarding_repository.dart';
+
+class OnboardingRepositoryImpl implements OnboardingRepository {
+  OnboardingRepositoryImpl(this._localDataSource);
+
+  final OnboardingLocalDataSource _localDataSource;
+
+  @override
+  Future<void> completeOnboarding() => _localDataSource.cacheOnboardingComplete();
+}
+
+final onboardingRepositoryProvider = Provider<OnboardingRepository>((ref) {
+  final dataSource = ref.read(onboardingLocalDataSourceProvider);
+  return OnboardingRepositoryImpl(dataSource);
+});
+
+final onboardingCompletionController = FutureProvider<void>((ref) async {
+  final repository = ref.read(onboardingRepositoryProvider);
+  await repository.completeOnboarding();
+});

--- a/lib/features/profile/presentation/pages/profile_page.dart
+++ b/lib/features/profile/presentation/pages/profile_page.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/localization/l10n.dart';
+import '../../../settings/presentation/pages/settings_page.dart';
+
+class ProfilePage extends StatelessWidget {
+  const ProfilePage({super.key});
+
+  static const routeName = 'profile';
+  static const routePath = '/profile';
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.profileTitle)),
+      body: ListView(
+        padding: const EdgeInsets.all(24),
+        children: [
+          CircleAvatar(
+            radius: 36,
+            child: Text(l10n.profileTitle.characters.first),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'ФИО пользователя',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 32),
+          ListTile(
+            leading: const Icon(Icons.settings_outlined),
+            title: Text(l10n.settingsTitle),
+            onTap: () => context.goNamed(SettingsPage.routeName),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/results/presentation/pages/results_page.dart
+++ b/lib/features/results/presentation/pages/results_page.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/localization/l10n.dart';
+
+class ResultsPage extends StatelessWidget {
+  const ResultsPage({super.key});
+
+  static const routeName = 'results';
+  static const routePath = '/results';
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.resultsTitle)),
+      body: const Center(
+        child: Text('Аналитика по результатам будет представлена здесь.'),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/localization/l10n.dart';
+import '../../../../core/providers/app_providers.dart';
+
+class SettingsPage extends ConsumerWidget {
+  const SettingsPage({super.key});
+
+  static const routeName = 'settings';
+  static const routePath = 'settings';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final themeMode = ref.watch(themeModeProvider);
+    final textScale = ref.watch(textScaleFactorProvider);
+    final locale = ref.watch(localeProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.settingsTitle)),
+      body: ListView(
+        padding: const EdgeInsets.all(24),
+        children: [
+          Text('Тема', style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 8),
+          SegmentedButton<ThemeMode>(
+            segments: const [
+              ButtonSegment(value: ThemeMode.system, label: Text('Система')),
+              ButtonSegment(value: ThemeMode.light, label: Text('Светлая')),
+              ButtonSegment(value: ThemeMode.dark, label: Text('Тёмная')),
+            ],
+            selected: {themeMode},
+            onSelectionChanged: (value) => ref.read(themeModeProvider.notifier).state = value.first,
+          ),
+          const SizedBox(height: 24),
+          Text('Размер текста', style: Theme.of(context).textTheme.titleMedium),
+          Slider(
+            value: textScale,
+            min: 0.8,
+            max: 1.4,
+            divisions: 6,
+            label: textScale.toStringAsFixed(1),
+            onChanged: (value) => ref.read(textScaleFactorProvider.notifier).state = value,
+          ),
+          const SizedBox(height: 24),
+          Text('Язык', style: Theme.of(context).textTheme.titleMedium),
+          DropdownButton<Locale>(
+            value: locale,
+            items: const [
+              DropdownMenuItem(value: Locale('ru'), child: Text('Русский')),
+              DropdownMenuItem(value: Locale('en'), child: Text('English')),
+            ],
+            onChanged: (value) {
+              if (value != null) {
+                ref.read(localeProvider.notifier).state = value;
+              }
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/survey/presentation/pages/survey_page.dart
+++ b/lib/features/survey/presentation/pages/survey_page.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/localization/l10n.dart';
+
+class SurveyPage extends StatelessWidget {
+  const SurveyPage({super.key});
+
+  static const routeName = 'survey';
+  static const routePath = '/survey';
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.surveyTitle)),
+      body: const Center(
+        child: Text('Конструктор опросов находится в разработке.'),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'core/localization/l10n.dart';
+import 'core/providers/app_providers.dart';
+import 'core/router/app_router.dart';
+import 'core/theme/app_theme.dart';
+
+void main() {
+  runApp(const ProviderScope(child: TochkaRostaApp()));
+}
+
+class TochkaRostaApp extends ConsumerWidget {
+  const TochkaRostaApp({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = ref.watch(appRouterProvider);
+    final themeMode = ref.watch(themeModeProvider);
+    final textScale = ref.watch(textScaleFactorProvider);
+
+    return MaterialApp.router(
+      title: AppLocalizations.defaultTitle,
+      routerConfig: router,
+      locale: ref.watch(localeProvider),
+      supportedLocales: AppLocalizations.supportedLocales,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      theme: AppTheme.light,
+      darkTheme: AppTheme.dark,
+      themeMode: themeMode,
+      builder: (context, child) {
+        final mediaQuery = MediaQuery.of(context);
+        return MediaQuery(
+          data: mediaQuery.copyWith(textScaler: TextScaler.linear(textScale)),
+          child: child ?? const SizedBox.shrink(),
+        );
+      },
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,43 @@
+name: tochka_rosta
+description: Skeleton Flutter app for TochkaRosta with Riverpod, go_router, Drift, and Dio.
+publish_to: "none"
+version: 0.1.0+1
+
+environment:
+  sdk: ">=3.2.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  flutter_riverpod: ^2.4.0
+  go_router: ^12.1.0
+  dio: ^5.4.0
+  dio_smart_retry: ^5.0.0
+  drift: ^2.14.1
+  drift_flutter: ^0.2.1
+  sqlite3_flutter_libs: ^0.5.0
+  path_provider: ^2.1.2
+  intl: ^0.19.0
+  firebase_core: ^2.24.2
+  firebase_analytics: ^10.7.2
+  firebase_messaging: ^14.7.5
+  freezed_annotation: ^2.4.1
+  json_annotation: ^4.8.1
+
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.1
+  build_runner: ^2.4.7
+  freezed: ^2.4.7
+  json_serializable: ^6.7.1
+  drift_dev: ^2.14.1
+
+flutter:
+  uses-material-design: true
+  generate: true
+  assets:
+    - assets/translations/


### PR DESCRIPTION
## Summary
- add Flutter pubspec with required dependencies and feature-first directory skeleton for TochkaRosta
- implement localization assets, app router with tab navigation, and shared theming widgets
- stub feature pages, Riverpod providers, Dio JWT interceptor, and Drift database placeholder for offline support

## Testing
- not run (Dart SDK is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68d5266c1f8083298e76157bf8e657a7