### PR TITLE
Add tochka_rosta_api FastAPI backend scaffold

### DIFF
--- a/tochka_rosta_api/.gitignore
+++ b/tochka_rosta_api/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.env

--- a/tochka_rosta_api/alembic.ini
+++ b/tochka_rosta_api/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = postgresql+asyncpg://user:password@localhost:5432/tochka_rosta
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/tochka_rosta_api/alembic/env.py
+++ b/tochka_rosta_api/alembic/env.py
@@ -1,0 +1,65 @@
+from logging.config import fileConfig
+
+from sqlalchemy import pool
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from alembic import context
+
+from app.core.config import get_settings
+from app.models import base as models_base
+from app.models import chat, file, push, report, response, survey, token, user
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+settings = get_settings()
+config.set_main_option("sqlalchemy.url", settings.database_url)
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = models_base.Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True, dialect_opts={"paramstyle": "named"})
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = async_engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+        future=True,
+    )
+
+    def do_run_migrations(connection: Connection) -> None:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+    import asyncio
+
+    async def run() -> None:
+        async with connectable.connect() as connection:
+            await connection.run_sync(do_run_migrations)
+        await connectable.dispose()
+
+    asyncio.run(run())
+
+
+def run_migrations() -> None:
+    if context.is_offline_mode():
+        run_migrations_offline()
+    else:
+        run_migrations_online()
+
+
+run_migrations()

--- a/tochka_rosta_api/alembic/versions/20240208_0001_init.py
+++ b/tochka_rosta_api/alembic/versions/20240208_0001_init.py
@@ -1,0 +1,156 @@
+"""Initial schema
+
+Revision ID: 20240208_0001
+Revises:
+Create Date: 2024-02-08 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20240208_0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("email", sa.String(length=255), nullable=False, unique=True),
+        sa.Column("password_hash", sa.String(length=255), nullable=False),
+        sa.Column("full_name", sa.String(), nullable=True),
+        sa.Column("role", sa.String(), nullable=False, server_default="user"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+
+    op.create_table(
+        "survey_versions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "chats",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("owner_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("participant_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "stored_files",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("owner_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("filename", sa.String(), nullable=False),
+        sa.Column("content_type", sa.String(), nullable=False),
+        sa.Column("path", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "push_tokens",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("token", sa.String(length=255), nullable=False, unique=True),
+        sa.Column("device_type", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "refresh_tokens",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("token", sa.String(length=255), nullable=False, unique=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "survey_sections",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("version_id", sa.Integer(), sa.ForeignKey("survey_versions.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("order", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "survey_questions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("section_id", sa.Integer(), sa.ForeignKey("survey_sections.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("text", sa.String(), nullable=False),
+        sa.Column("question_type", sa.String(length=50), nullable=False),
+        sa.Column("order", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "responses",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("survey_version_id", sa.Integer(), sa.ForeignKey("survey_versions.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("submitted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "reports",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("response_id", sa.Integer(), sa.ForeignKey("responses.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("status", sa.String(length=50), nullable=False, server_default="new"),
+        sa.Column("summary", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "response_answers",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("response_id", sa.Integer(), sa.ForeignKey("responses.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("question_id", sa.Integer(), sa.ForeignKey("survey_questions.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("answer", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "messages",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("chat_id", sa.Integer(), sa.ForeignKey("chats.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("sender_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("content", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("messages")
+    op.drop_table("response_answers")
+    op.drop_table("reports")
+    op.drop_table("responses")
+    op.drop_table("survey_questions")
+    op.drop_table("survey_sections")
+    op.drop_table("refresh_tokens")
+    op.drop_table("push_tokens")
+    op.drop_table("stored_files")
+    op.drop_table("chats")
+    op.drop_table("survey_versions")
+    op.drop_index("ix_users_email", table_name="users")
+    op.drop_table("users")

--- a/tochka_rosta_api/app/__init__.py
+++ b/tochka_rosta_api/app/__init__.py
@@ -1,0 +1,3 @@
+from .main import app
+
+__all__ = ["app"]

--- a/tochka_rosta_api/app/core/config.py
+++ b/tochka_rosta_api/app/core/config.py
@@ -1,0 +1,27 @@
+from functools import lru_cache
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    app_name: str = "tochka_rosta_api"
+    debug: bool = False
+    database_url: str = "postgresql+asyncpg://user:password@localhost:5432/tochka_rosta"
+
+    jwt_secret_key: str = "CHANGE_ME"
+    jwt_refresh_secret_key: str = "CHANGE_ME_REFRESH"
+    jwt_algorithm: str = "HS256"
+    access_token_expire_minutes: int = 15
+    refresh_token_expire_minutes: int = 60 * 24 * 7
+
+    cors_origins: list[str] = ["*"]
+    rate_limit_requests: int = 100
+    rate_limit_window_seconds: int = 60
+
+    file_storage_dir: str = "app/files/storage"
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/tochka_rosta_api/app/core/database.py
+++ b/tochka_rosta_api/app/core/database.py
@@ -1,0 +1,17 @@
+from typing import AsyncIterator
+
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from .config import get_settings
+
+
+settings = get_settings()
+
+engine: AsyncEngine = create_async_engine(settings.database_url, echo=settings.debug, future=True)
+async_session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+
+async def get_session() -> AsyncIterator[AsyncSession]:
+    async with async_session_factory() as session:
+        yield session

--- a/tochka_rosta_api/app/core/security.py
+++ b/tochka_rosta_api/app/core/security.py
@@ -1,0 +1,91 @@
+from datetime import datetime, timedelta
+from functools import wraps
+from typing import Any, Callable, Coroutine, Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+from ..schemas.auth import TokenPayload
+from ..repositories.user import UserRepository
+from ..models.user import User
+from .config import get_settings
+from .database import get_session
+
+
+pwd_context = CryptContext(schemes=["argon2"], deprecated="auto")
+settings = get_settings()
+oauth2_scheme = HTTPBearer(auto_error=False)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def hash_password(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def _create_token(subject: str, expires_delta: timedelta, secret: str) -> str:
+    expire = datetime.utcnow() + expires_delta
+    payload = {"sub": subject, "exp": expire}
+    return jwt.encode(payload, secret, algorithm=settings.jwt_algorithm)
+
+
+def create_access_token(subject: str) -> str:
+    return _create_token(subject, timedelta(minutes=settings.access_token_expire_minutes), settings.jwt_secret_key)
+
+
+def create_refresh_token(subject: str) -> str:
+    return _create_token(subject, timedelta(minutes=settings.refresh_token_expire_minutes), settings.jwt_refresh_secret_key)
+
+
+def decode_access_token(token: str) -> TokenPayload:
+    try:
+        payload = jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+        return TokenPayload(sub=payload.get("sub"))
+    except JWTError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token") from exc
+
+
+def decode_refresh_token(token: str) -> TokenPayload:
+    try:
+        payload = jwt.decode(token, settings.jwt_refresh_secret_key, algorithms=[settings.jwt_algorithm])
+        return TokenPayload(sub=payload.get("sub"))
+    except JWTError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token") from exc
+
+
+async def get_current_user(
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(oauth2_scheme),
+    session=Depends(get_session),
+) -> User:
+    if credentials is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+
+    token_payload = decode_access_token(credentials.credentials)
+    if token_payload.sub is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload")
+
+    repo = UserRepository(session)
+    user = await repo.get_by_email(token_payload.sub)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+    return user
+
+
+def require_role(role: str) -> Callable[[Callable[..., Coroutine[Any, Any, Any]]], Callable[..., Coroutine[Any, Any, Any]]]:
+    def decorator(func: Callable[..., Coroutine[Any, Any, Any]]):
+        @wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any):
+            current_user: Optional[User] = kwargs.get("current_user")
+            if current_user is None:
+                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+            if current_user.role != role:
+                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+            return await func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tochka_rosta_api/app/main.py
+++ b/tochka_rosta_api/app/main.py
@@ -1,0 +1,42 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
+from slowapi.util import get_remote_address
+
+from .core.config import get_settings
+from .routers import auth, chat, files, push, reports, responses, survey, users
+
+settings = get_settings()
+limiter = Limiter(key_func=get_remote_address, default_limits=[
+    f"{settings.rate_limit_requests}/{settings.rate_limit_window_seconds} seconds"
+])
+
+app = FastAPI(title=settings.app_name, debug=settings.debug)
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+app.add_middleware(SlowAPIMiddleware)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.cors_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(auth.router)
+app.include_router(users.router)
+app.include_router(survey.router)
+app.include_router(responses.router)
+app.include_router(reports.router)
+app.include_router(chat.router)
+app.include_router(files.router)
+app.include_router(push.router)
+
+
+@app.get("/health", tags=["system"])
+@limiter.limit("10/60 seconds")
+async def healthcheck():
+    return {"status": "ok"}

--- a/tochka_rosta_api/app/models/__init__.py
+++ b/tochka_rosta_api/app/models/__init__.py
@@ -1,0 +1,3 @@
+from .base import Base
+
+__all__ = ["Base"]

--- a/tochka_rosta_api/app/models/base.py
+++ b/tochka_rosta_api/app/models/base.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, func
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class TimestampMixin:
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )

--- a/tochka_rosta_api/app/models/chat.py
+++ b/tochka_rosta_api/app/models/chat.py
@@ -1,0 +1,28 @@
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base, TimestampMixin
+
+
+class Chat(TimestampMixin, Base):
+    __tablename__ = "chats"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    owner_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    participant_id: Mapped[int | None] = mapped_column(ForeignKey("users.id", ondelete="SET NULL"))
+
+    owner = relationship("User", foreign_keys=[owner_id], back_populates="chats")
+    participant = relationship("User", foreign_keys=[participant_id])
+    messages = relationship("Message", back_populates="chat", cascade="all, delete-orphan")
+
+
+class Message(TimestampMixin, Base):
+    __tablename__ = "messages"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    chat_id: Mapped[int] = mapped_column(ForeignKey("chats.id", ondelete="CASCADE"))
+    sender_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    content: Mapped[str] = mapped_column(String)
+
+    chat = relationship("Chat", back_populates="messages")
+    sender = relationship("User")

--- a/tochka_rosta_api/app/models/file.py
+++ b/tochka_rosta_api/app/models/file.py
@@ -1,0 +1,16 @@
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base, TimestampMixin
+
+
+class StoredFile(TimestampMixin, Base):
+    __tablename__ = "stored_files"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    owner_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    filename: Mapped[str] = mapped_column(String(255))
+    content_type: Mapped[str] = mapped_column(String(255))
+    path: Mapped[str] = mapped_column(String)
+
+    owner = relationship("User", back_populates="files")

--- a/tochka_rosta_api/app/models/push.py
+++ b/tochka_rosta_api/app/models/push.py
@@ -1,0 +1,15 @@
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base, TimestampMixin
+
+
+class PushToken(TimestampMixin, Base):
+    __tablename__ = "push_tokens"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    token: Mapped[str] = mapped_column(String(255), unique=True)
+    device_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
+    user = relationship("User", back_populates="push_tokens")

--- a/tochka_rosta_api/app/models/report.py
+++ b/tochka_rosta_api/app/models/report.py
@@ -1,0 +1,17 @@
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base, TimestampMixin
+
+
+class Report(TimestampMixin, Base):
+    __tablename__ = "reports"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    response_id: Mapped[int] = mapped_column(ForeignKey("responses.id", ondelete="CASCADE"))
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    status: Mapped[str] = mapped_column(String(50), default="new")
+    summary: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    response = relationship("Response", back_populates="report")
+    user = relationship("User", back_populates="reports")

--- a/tochka_rosta_api/app/models/response.py
+++ b/tochka_rosta_api/app/models/response.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base, TimestampMixin
+
+
+class Response(TimestampMixin, Base):
+    __tablename__ = "responses"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    survey_version_id: Mapped[int] = mapped_column(ForeignKey("survey_versions.id", ondelete="CASCADE"))
+    submitted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    user = relationship("User", back_populates="responses")
+    survey_version = relationship("SurveyVersion", back_populates="responses")
+    answers = relationship("ResponseAnswer", back_populates="response", cascade="all, delete-orphan")
+    report = relationship("Report", back_populates="response", uselist=False)
+
+
+class ResponseAnswer(TimestampMixin, Base):
+    __tablename__ = "response_answers"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    response_id: Mapped[int] = mapped_column(ForeignKey("responses.id", ondelete="CASCADE"))
+    question_id: Mapped[int] = mapped_column(ForeignKey("survey_questions.id", ondelete="CASCADE"))
+    answer: Mapped[str] = mapped_column(String)
+
+    response = relationship("Response", back_populates="answers")
+    question = relationship("SurveyQuestion", back_populates="answers")

--- a/tochka_rosta_api/app/models/survey.py
+++ b/tochka_rosta_api/app/models/survey.py
@@ -1,0 +1,40 @@
+from sqlalchemy import Boolean, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base, TimestampMixin
+
+
+class SurveyVersion(TimestampMixin, Base):
+    __tablename__ = "survey_versions"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str] = mapped_column(String(255))
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+
+    sections = relationship("SurveySection", back_populates="version", cascade="all, delete-orphan")
+    responses = relationship("Response", back_populates="survey_version")
+
+
+class SurveySection(TimestampMixin, Base):
+    __tablename__ = "survey_sections"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    version_id: Mapped[int] = mapped_column(ForeignKey("survey_versions.id", ondelete="CASCADE"))
+    title: Mapped[str] = mapped_column(String(255))
+    order: Mapped[int] = mapped_column(Integer)
+
+    version = relationship("SurveyVersion", back_populates="sections")
+    questions = relationship("SurveyQuestion", back_populates="section", cascade="all, delete-orphan")
+
+
+class SurveyQuestion(TimestampMixin, Base):
+    __tablename__ = "survey_questions"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    section_id: Mapped[int] = mapped_column(ForeignKey("survey_sections.id", ondelete="CASCADE"))
+    text: Mapped[str] = mapped_column(String)
+    question_type: Mapped[str] = mapped_column(String(50))
+    order: Mapped[int] = mapped_column(Integer)
+
+    section = relationship("SurveySection", back_populates="questions")
+    answers = relationship("ResponseAnswer", back_populates="question")

--- a/tochka_rosta_api/app/models/token.py
+++ b/tochka_rosta_api/app/models/token.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base, TimestampMixin
+
+
+class RefreshToken(TimestampMixin, Base):
+    __tablename__ = "refresh_tokens"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    token: Mapped[str] = mapped_column(String(255), unique=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+    user = relationship("User")

--- a/tochka_rosta_api/app/models/user.py
+++ b/tochka_rosta_api/app/models/user.py
@@ -1,0 +1,20 @@
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base, TimestampMixin
+
+
+class User(TimestampMixin, Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    email: Mapped[str] = mapped_column(String(255), unique=True, index=True)
+    password_hash: Mapped[str] = mapped_column(String(255))
+    full_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    role: Mapped[str] = mapped_column(String(50), default="user")
+
+    responses = relationship("Response", back_populates="user")
+    reports = relationship("Report", back_populates="user")
+    chats = relationship("Chat", back_populates="owner")
+    files = relationship("StoredFile", back_populates="owner")
+    push_tokens = relationship("PushToken", back_populates="user")

--- a/tochka_rosta_api/app/repositories/base.py
+++ b/tochka_rosta_api/app/repositories/base.py
@@ -1,0 +1,32 @@
+from typing import Any, Generic, Sequence, TypeVar
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+ModelType = TypeVar("ModelType")
+
+
+class BaseRepository(Generic[ModelType]):
+    def __init__(self, session: AsyncSession, model: type[ModelType]):
+        self.session = session
+        self.model = model
+
+    async def get(self, obj_id: Any) -> ModelType | None:
+        result = await self.session.execute(select(self.model).where(self.model.id == obj_id))
+        return result.scalar_one_or_none()
+
+    async def list(self, **filters: Any) -> Sequence[ModelType]:
+        stmt = select(self.model)
+        for attr, value in filters.items():
+            stmt = stmt.where(getattr(self.model, attr) == value)
+        result = await self.session.execute(stmt)
+        return result.scalars().all()
+
+    async def add(self, instance: ModelType) -> ModelType:
+        self.session.add(instance)
+        await self.session.flush()
+        return instance
+
+    async def delete(self, instance: ModelType) -> None:
+        await self.session.delete(instance)

--- a/tochka_rosta_api/app/repositories/chat.py
+++ b/tochka_rosta_api/app/repositories/chat.py
@@ -1,0 +1,24 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.chat import Chat, Message
+from .base import BaseRepository
+
+
+class ChatRepository(BaseRepository[Chat]):
+    def __init__(self, session: AsyncSession):
+        super().__init__(session, Chat)
+
+    async def list_for_user(self, user_id: int) -> list[Chat]:
+        stmt = select(Chat).where((Chat.owner_id == user_id) | (Chat.participant_id == user_id))
+        result = await self.session.execute(stmt)
+        return result.scalars().all()
+
+
+class MessageRepository(BaseRepository[Message]):
+    def __init__(self, session: AsyncSession):
+        super().__init__(session, Message)
+
+    async def list_for_chat(self, chat_id: int) -> list[Message]:
+        result = await self.session.execute(select(Message).where(Message.chat_id == chat_id))
+        return result.scalars().all()

--- a/tochka_rosta_api/app/repositories/file.py
+++ b/tochka_rosta_api/app/repositories/file.py
@@ -1,0 +1,14 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.file import StoredFile
+from .base import BaseRepository
+
+
+class FileRepository(BaseRepository[StoredFile]):
+    def __init__(self, session: AsyncSession):
+        super().__init__(session, StoredFile)
+
+    async def list_by_owner(self, owner_id: int) -> list[StoredFile]:
+        result = await self.session.execute(select(StoredFile).where(StoredFile.owner_id == owner_id))
+        return result.scalars().all()

--- a/tochka_rosta_api/app/repositories/push.py
+++ b/tochka_rosta_api/app/repositories/push.py
@@ -1,0 +1,14 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.push import PushToken
+from .base import BaseRepository
+
+
+class PushTokenRepository(BaseRepository[PushToken]):
+    def __init__(self, session: AsyncSession):
+        super().__init__(session, PushToken)
+
+    async def get_by_token(self, token: str) -> PushToken | None:
+        result = await self.session.execute(select(PushToken).where(PushToken.token == token))
+        return result.scalar_one_or_none()

--- a/tochka_rosta_api/app/repositories/report.py
+++ b/tochka_rosta_api/app/repositories/report.py
@@ -1,0 +1,14 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.report import Report
+from .base import BaseRepository
+
+
+class ReportRepository(BaseRepository[Report]):
+    def __init__(self, session: AsyncSession):
+        super().__init__(session, Report)
+
+    async def list_by_user(self, user_id: int) -> list[Report]:
+        result = await self.session.execute(select(Report).where(Report.user_id == user_id))
+        return result.scalars().all()

--- a/tochka_rosta_api/app/repositories/response.py
+++ b/tochka_rosta_api/app/repositories/response.py
@@ -1,0 +1,29 @@
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.response import Response, ResponseAnswer
+from .base import BaseRepository
+
+
+class ResponseRepository(BaseRepository[Response]):
+    def __init__(self, session: AsyncSession):
+        super().__init__(session, Response)
+
+    async def get(self, obj_id: int) -> Response | None:
+        stmt = select(Response).options(selectinload(Response.answers)).where(Response.id == obj_id)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def list_by_user(self, user_id: int) -> list[Response]:
+        stmt = select(Response).options(selectinload(Response.answers)).where(Response.user_id == user_id)
+        result = await self.session.execute(stmt)
+        return result.scalars().all()
+
+
+class ResponseAnswerRepository(BaseRepository[ResponseAnswer]):
+    def __init__(self, session: AsyncSession):
+        super().__init__(session, ResponseAnswer)
+
+    async def delete_for_response(self, response_id: int) -> None:
+        await self.session.execute(ResponseAnswer.__table__.delete().where(ResponseAnswer.response_id == response_id))

--- a/tochka_rosta_api/app/repositories/survey.py
+++ b/tochka_rosta_api/app/repositories/survey.py
@@ -1,0 +1,24 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.survey import SurveyQuestion, SurveySection, SurveyVersion
+from .base import BaseRepository
+
+
+class SurveyVersionRepository(BaseRepository[SurveyVersion]):
+    def __init__(self, session: AsyncSession):
+        super().__init__(session, SurveyVersion)
+
+    async def list_active(self) -> list[SurveyVersion]:
+        result = await self.session.execute(select(SurveyVersion).where(SurveyVersion.is_active.is_(True)))
+        return result.scalars().all()
+
+
+class SurveySectionRepository(BaseRepository[SurveySection]):
+    def __init__(self, session: AsyncSession):
+        super().__init__(session, SurveySection)
+
+
+class SurveyQuestionRepository(BaseRepository[SurveyQuestion]):
+    def __init__(self, session: AsyncSession):
+        super().__init__(session, SurveyQuestion)

--- a/tochka_rosta_api/app/repositories/token.py
+++ b/tochka_rosta_api/app/repositories/token.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.token import RefreshToken
+from .base import BaseRepository
+
+
+class RefreshTokenRepository(BaseRepository[RefreshToken]):
+    def __init__(self, session: AsyncSession):
+        super().__init__(session, RefreshToken)
+
+    async def get_valid(self, token: str, now: datetime) -> RefreshToken | None:
+        stmt = select(RefreshToken).where(RefreshToken.token == token, RefreshToken.expires_at >= now)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def delete_user_tokens(self, user_id: int) -> None:
+        await self.session.execute(RefreshToken.__table__.delete().where(RefreshToken.user_id == user_id))

--- a/tochka_rosta_api/app/repositories/user.py
+++ b/tochka_rosta_api/app/repositories/user.py
@@ -1,0 +1,14 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.user import User
+from .base import BaseRepository
+
+
+class UserRepository(BaseRepository[User]):
+    def __init__(self, session: AsyncSession):
+        super().__init__(session, User)
+
+    async def get_by_email(self, email: str) -> User | None:
+        result = await self.session.execute(select(User).where(User.email == email))
+        return result.scalar_one_or_none()

--- a/tochka_rosta_api/app/routers/__init__.py
+++ b/tochka_rosta_api/app/routers/__init__.py
@@ -1,0 +1,12 @@
+from . import auth, chat, files, push, reports, responses, survey, users
+
+__all__ = [
+    "auth",
+    "chat",
+    "files",
+    "push",
+    "reports",
+    "responses",
+    "survey",
+    "users",
+]

--- a/tochka_rosta_api/app/routers/auth.py
+++ b/tochka_rosta_api/app/routers/auth.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.database import get_session
+from ..schemas.auth import LoginRequest, RefreshRequest, TokenResponse
+from ..schemas.user import UserCreate
+from ..services.auth import AuthService
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/register", response_model=TokenResponse)
+async def register(payload: UserCreate, session: AsyncSession = Depends(get_session)) -> TokenResponse:
+    service = AuthService(session)
+    return await service.register(payload)
+
+
+@router.post("/login", response_model=TokenResponse)
+async def login(payload: LoginRequest, session: AsyncSession = Depends(get_session)) -> TokenResponse:
+    service = AuthService(session)
+    return await service.authenticate(payload.email, payload.password)
+
+
+@router.post("/refresh", response_model=TokenResponse)
+async def refresh(payload: RefreshRequest, session: AsyncSession = Depends(get_session)) -> TokenResponse:
+    service = AuthService(session)
+    return await service.refresh(payload.refresh_token)

--- a/tochka_rosta_api/app/routers/chat.py
+++ b/tochka_rosta_api/app/routers/chat.py
@@ -1,0 +1,50 @@
+from fastapi import APIRouter, Depends, Path, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.database import get_session
+from ..core.security import get_current_user
+from ..models.user import User
+from ..schemas.chat import ChatCreate, ChatRead, MessageCreate, MessageRead
+from ..services.chat import ChatService
+
+router = APIRouter(prefix="/chat", tags=["chat"])
+
+
+@router.get("", response_model=list[ChatRead])
+async def list_chats(
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> list[ChatRead]:
+    service = ChatService(session)
+    return await service.list_for_user(current_user.id)
+
+
+@router.post("", response_model=ChatRead, status_code=status.HTTP_201_CREATED)
+async def create_chat(
+    payload: ChatCreate,
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> ChatRead:
+    service = ChatService(session)
+    return await service.create(current_user.id, payload)
+
+
+@router.get("/{chat_id}/messages", response_model=list[MessageRead])
+async def list_messages(
+    chat_id: int = Path(..., ge=1),
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> list[MessageRead]:
+    service = ChatService(session)
+    return await service.list_messages(chat_id, current_user.id)
+
+
+@router.post("/{chat_id}/messages", response_model=MessageRead, status_code=status.HTTP_201_CREATED)
+async def send_message(
+    payload: MessageCreate,
+    chat_id: int = Path(..., ge=1),
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> MessageRead:
+    service = ChatService(session)
+    return await service.add_message(chat_id, current_user.id, payload)

--- a/tochka_rosta_api/app/routers/files.py
+++ b/tochka_rosta_api/app/routers/files.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+from fastapi.responses import FileResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.database import get_session
+from ..core.security import get_current_user
+from ..models.user import User
+from ..schemas.file import FileRead
+from ..services.file import FileService
+
+router = APIRouter(prefix="/files", tags=["files"])
+
+
+@router.post("/upload", response_model=FileRead, status_code=status.HTTP_201_CREATED)
+async def upload_file(
+    file: UploadFile,
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> FileRead:
+    service = FileService(session)
+    return await service.upload(current_user.id, file)
+
+
+@router.get("/{file_id}")
+async def get_file(
+    file_id: int,
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    service = FileService(session)
+    try:
+        stored = await service.get(file_id, current_user.id)
+    except FileNotFoundError as exc:  # noqa: PERF203
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found") from exc
+    return FileResponse(stored.path, media_type=stored.content_type, filename=stored.filename)

--- a/tochka_rosta_api/app/routers/push.py
+++ b/tochka_rosta_api/app/routers/push.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.database import get_session
+from ..core.security import get_current_user
+from ..models.push import PushToken
+from ..models.user import User
+from ..schemas.push import PushRegisterRequest
+from ..services.push import PushService
+
+router = APIRouter(prefix="/push", tags=["push"])
+
+
+@router.post("/register", response_model=PushRegisterRequest, status_code=status.HTTP_201_CREATED)
+async def register_push(
+    payload: PushRegisterRequest,
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> PushRegisterRequest:
+    service = PushService(session)
+    token: PushToken = await service.register(current_user.id, payload)
+    return PushRegisterRequest(token=token.token, device_type=token.device_type)

--- a/tochka_rosta_api/app/routers/reports.py
+++ b/tochka_rosta_api/app/routers/reports.py
@@ -1,0 +1,42 @@
+from fastapi import APIRouter, Depends, Path
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.database import get_session
+from ..core.security import get_current_user, require_role
+from ..models.user import User
+from ..schemas.report import ReportRead, ReportUpdate
+from ..services.report import ReportService
+
+router = APIRouter(prefix="/reports", tags=["reports"])
+
+
+@router.get("", response_model=list[ReportRead])
+async def my_reports(
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> list[ReportRead]:
+    service = ReportService(session)
+    return await service.list_my_reports(current_user.id)
+
+
+@router.get("/{report_id}", response_model=ReportRead)
+@require_role("moderator")
+async def get_report(
+    report_id: int = Path(..., ge=1),
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> ReportRead:
+    service = ReportService(session)
+    return await service.get(report_id)
+
+
+@router.patch("/{report_id}", response_model=ReportRead)
+@require_role("moderator")
+async def update_report(
+    payload: ReportUpdate,
+    report_id: int = Path(..., ge=1),
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> ReportRead:
+    service = ReportService(session)
+    return await service.update(report_id, payload)

--- a/tochka_rosta_api/app/routers/responses.py
+++ b/tochka_rosta_api/app/routers/responses.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, Depends, HTTPException, Path, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.database import get_session
+from ..core.security import get_current_user
+from ..models.user import User
+from ..schemas.response import ResponseCreate, ResponseRead, ResponseUpdate
+from ..services.response import ResponseService
+
+router = APIRouter(prefix="/responses", tags=["responses"])
+
+
+@router.get("", response_model=list[ResponseRead])
+async def list_responses(
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> list[ResponseRead]:
+    service = ResponseService(session)
+    return await service.list_for_user(current_user.id)
+
+
+@router.post("", response_model=ResponseRead, status_code=status.HTTP_201_CREATED)
+async def create_response(
+    payload: ResponseCreate,
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> ResponseRead:
+    service = ResponseService(session)
+    return await service.create(current_user.id, payload)
+
+
+@router.put("/{response_id}", response_model=ResponseRead)
+async def update_response(
+    payload: ResponseUpdate,
+    response_id: int = Path(..., ge=1),
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> ResponseRead:
+    service = ResponseService(session)
+    return await service.update(response_id, current_user.id, payload)

--- a/tochka_rosta_api/app/routers/survey.py
+++ b/tochka_rosta_api/app/routers/survey.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.database import get_session
+from ..schemas.survey import SurveyQuestionRead, SurveySectionRead, SurveyVersionRead
+from ..services.survey import SurveyService
+
+router = APIRouter(prefix="/survey", tags=["survey"])
+
+
+@router.get("/versions", response_model=list[SurveyVersionRead])
+async def get_versions(session: AsyncSession = Depends(get_session)) -> list[SurveyVersionRead]:
+    service = SurveyService(session)
+    return await service.get_active_versions()
+
+
+@router.get("/sections", response_model=list[SurveySectionRead])
+async def get_sections(
+    version_id: int = Query(..., description="Survey version identifier"),
+    session: AsyncSession = Depends(get_session),
+) -> list[SurveySectionRead]:
+    service = SurveyService(session)
+    return await service.get_sections(version_id)
+
+
+@router.get("/questions", response_model=list[SurveyQuestionRead])
+async def get_questions(
+    section_id: int = Query(..., description="Survey section identifier"),
+    session: AsyncSession = Depends(get_session),
+) -> list[SurveyQuestionRead]:
+    service = SurveyService(session)
+    return await service.get_questions(section_id)

--- a/tochka_rosta_api/app/routers/users.py
+++ b/tochka_rosta_api/app/routers/users.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.database import get_session
+from ..core.security import get_current_user
+from ..models.user import User
+from ..schemas.user import UserRead
+from ..services.user import UserService
+
+router = APIRouter(tags=["users"])
+
+
+@router.get("/me", response_model=UserRead)
+async def read_profile(
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> UserRead:
+    service = UserService(session)
+    profile = await service.get_profile(current_user.id)
+    if profile is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return profile

--- a/tochka_rosta_api/app/schemas/auth.py
+++ b/tochka_rosta_api/app/schemas/auth.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel, EmailStr
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+
+class TokenPayload(BaseModel):
+    sub: EmailStr | None
+
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str

--- a/tochka_rosta_api/app/schemas/base.py
+++ b/tochka_rosta_api/app/schemas/base.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class ORMBase(BaseModel):
+    class Config:
+        from_attributes = True
+
+
+class Timestamped(ORMBase):
+    created_at: datetime
+    updated_at: datetime

--- a/tochka_rosta_api/app/schemas/chat.py
+++ b/tochka_rosta_api/app/schemas/chat.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+from .base import ORMBase
+
+
+class ChatCreate(BaseModel):
+    participant_id: int | None = None
+
+
+class ChatRead(ORMBase):
+    id: int
+    owner_id: int
+    participant_id: int | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class MessageCreate(BaseModel):
+    content: str
+
+
+class MessageRead(ORMBase):
+    id: int
+    chat_id: int
+    sender_id: int
+    content: str
+    created_at: datetime
+    updated_at: datetime

--- a/tochka_rosta_api/app/schemas/file.py
+++ b/tochka_rosta_api/app/schemas/file.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+from .base import ORMBase
+
+
+class FileRead(ORMBase):
+    id: int
+    owner_id: int
+    filename: str
+    content_type: str
+    path: str
+    created_at: datetime
+    updated_at: datetime

--- a/tochka_rosta_api/app/schemas/push.py
+++ b/tochka_rosta_api/app/schemas/push.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class PushRegisterRequest(BaseModel):
+    token: str
+    device_type: str | None = None

--- a/tochka_rosta_api/app/schemas/report.py
+++ b/tochka_rosta_api/app/schemas/report.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+from .base import ORMBase
+
+
+ReportStatus = Literal["new", "in_review", "approved", "rejected"]
+
+
+class ReportCreate(BaseModel):
+    response_id: int
+    summary: str | None = None
+
+
+class ReportUpdate(BaseModel):
+    status: ReportStatus | None = None
+    summary: str | None = None
+
+
+class ReportRead(ORMBase):
+    id: int
+    response_id: int
+    user_id: int
+    status: ReportStatus
+    summary: str | None
+    created_at: datetime
+    updated_at: datetime

--- a/tochka_rosta_api/app/schemas/response.py
+++ b/tochka_rosta_api/app/schemas/response.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+from typing import List
+
+from pydantic import BaseModel
+
+from .base import ORMBase
+
+
+class ResponseAnswer(BaseModel):
+    question_id: int
+    answer: str
+
+
+class ResponseCreate(BaseModel):
+    survey_version_id: int
+    answers: List[ResponseAnswer]
+
+
+class ResponseUpdate(BaseModel):
+    answers: List[ResponseAnswer]
+
+
+class ResponseRead(ORMBase):
+    id: int
+    user_id: int
+    survey_version_id: int
+    submitted_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+    answers: List[ResponseAnswer]

--- a/tochka_rosta_api/app/schemas/survey.py
+++ b/tochka_rosta_api/app/schemas/survey.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+from .base import ORMBase
+
+
+class SurveyVersionCreate(BaseModel):
+    title: str
+    is_active: bool = True
+
+
+class SurveyVersionRead(ORMBase):
+    id: int
+    title: str
+    is_active: bool
+    created_at: datetime
+
+
+class SurveySectionCreate(BaseModel):
+    version_id: int
+    title: str
+    order: int
+
+
+class SurveySectionRead(ORMBase):
+    id: int
+    version_id: int
+    title: str
+    order: int
+
+
+class SurveyQuestionCreate(BaseModel):
+    section_id: int
+    text: str
+    question_type: str
+    order: int
+
+
+class SurveyQuestionRead(ORMBase):
+    id: int
+    section_id: int
+    text: str
+    question_type: str
+    order: int

--- a/tochka_rosta_api/app/schemas/user.py
+++ b/tochka_rosta_api/app/schemas/user.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from pydantic import BaseModel, EmailStr, Field
+
+from .base import ORMBase
+
+
+class UserCreate(BaseModel):
+    email: EmailStr
+    password: str = Field(min_length=8)
+    full_name: str | None = None
+
+
+class UserRead(ORMBase):
+    id: int
+    email: EmailStr
+    full_name: str | None
+    role: str
+    created_at: datetime
+    updated_at: datetime

--- a/tochka_rosta_api/app/services/auth.py
+++ b/tochka_rosta_api/app/services/auth.py
@@ -1,0 +1,60 @@
+from datetime import datetime, timedelta
+
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.config import get_settings
+from ..core.security import create_access_token, create_refresh_token, hash_password, verify_password
+from ..models.token import RefreshToken
+from ..repositories.token import RefreshTokenRepository
+from ..repositories.user import UserRepository
+from ..schemas.auth import TokenResponse
+from ..schemas.user import UserCreate
+
+
+class AuthService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+        self.user_repo = UserRepository(session)
+        self.refresh_repo = RefreshTokenRepository(session)
+        self.settings = get_settings()
+
+    async def register(self, payload: UserCreate) -> TokenResponse:
+        existing = await self.user_repo.get_by_email(payload.email)
+        if existing:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already registered")
+
+        from ..models.user import User
+
+        user = User(email=payload.email, password_hash=hash_password(payload.password), full_name=payload.full_name)
+        await self.user_repo.add(user)
+        await self.session.commit()
+        return await self._issue_tokens(user.email, user.id)
+
+    async def authenticate(self, email: str, password: str) -> TokenResponse:
+        user = await self.user_repo.get_by_email(email)
+        if not user or not verify_password(password, user.password_hash):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect credentials")
+        return await self._issue_tokens(user.email, user.id)
+
+    async def refresh(self, token: str) -> TokenResponse:
+        now = datetime.utcnow()
+        refresh = await self.refresh_repo.get_valid(token, now)
+        if not refresh:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token")
+        user = await self.user_repo.get(refresh.user_id)
+        if not user:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+        await self.refresh_repo.delete_user_tokens(user.id)
+        await self.session.commit()
+        return await self._issue_tokens(user.email, user.id)
+
+    async def _issue_tokens(self, email: str, user_id: int) -> TokenResponse:
+        access_token = create_access_token(email)
+        refresh_token = create_refresh_token(email)
+
+        expires_at = datetime.utcnow() + timedelta(minutes=self.settings.refresh_token_expire_minutes)
+        token_model = RefreshToken(user_id=user_id, token=refresh_token, expires_at=expires_at)
+        await self.refresh_repo.add(token_model)
+        await self.session.commit()
+        return TokenResponse(access_token=access_token, refresh_token=refresh_token)

--- a/tochka_rosta_api/app/services/chat.py
+++ b/tochka_rosta_api/app/services/chat.py
@@ -1,0 +1,46 @@
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..repositories.chat import ChatRepository, MessageRepository
+from ..schemas.chat import ChatCreate, ChatRead, MessageCreate, MessageRead
+
+
+class ChatService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+        self.chat_repo = ChatRepository(session)
+        self.message_repo = MessageRepository(session)
+
+    async def list_for_user(self, owner_id: int) -> list[ChatRead]:
+        chats = await self.chat_repo.list_for_user(owner_id)
+        return [ChatRead.model_validate(chat) for chat in chats]
+
+    async def create(self, owner_id: int, payload: ChatCreate) -> ChatRead:
+        from ..models.chat import Chat
+
+        chat = Chat(owner_id=owner_id, participant_id=payload.participant_id)
+        await self.chat_repo.add(chat)
+        await self.session.commit()
+        await self.session.refresh(chat)
+        return ChatRead.model_validate(chat)
+
+    async def get(self, chat_id: int, user_id: int) -> ChatRead:
+        chat = await self.chat_repo.get(chat_id)
+        if not chat or (chat.owner_id != user_id and chat.participant_id != user_id):
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Chat not found")
+        return ChatRead.model_validate(chat)
+
+    async def list_messages(self, chat_id: int, user_id: int) -> list[MessageRead]:
+        await self.get(chat_id, user_id)
+        messages = await self.message_repo.list_for_chat(chat_id)
+        return [MessageRead.model_validate(msg) for msg in messages]
+
+    async def add_message(self, chat_id: int, user_id: int, payload: MessageCreate) -> MessageRead:
+        await self.get(chat_id, user_id)
+        from ..models.chat import Message
+
+        message = Message(chat_id=chat_id, sender_id=user_id, content=payload.content)
+        await self.message_repo.add(message)
+        await self.session.commit()
+        await self.session.refresh(message)
+        return MessageRead.model_validate(message)

--- a/tochka_rosta_api/app/services/file.py
+++ b/tochka_rosta_api/app/services/file.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+from fastapi import UploadFile
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.config import get_settings
+from ..repositories.file import FileRepository
+from ..schemas.file import FileRead
+from ..models.file import StoredFile
+
+settings = get_settings()
+
+
+class FileService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+        self.file_repo = FileRepository(session)
+        Path(settings.file_storage_dir).mkdir(parents=True, exist_ok=True)
+
+    async def upload(self, owner_id: int, upload: UploadFile) -> FileRead:
+        filename = upload.filename or "file"
+        file_path = Path(settings.file_storage_dir) / filename
+        counter = 1
+        while file_path.exists():
+            file_path = Path(settings.file_storage_dir) / f"{counter}_{filename}"
+            counter += 1
+
+        contents = await upload.read()
+        await upload.close()
+
+        with open(file_path, "wb") as buffer:
+            buffer.write(contents)
+
+        from ..models.file import StoredFile
+
+        stored = StoredFile(
+            owner_id=owner_id,
+            filename=filename,
+            content_type=upload.content_type or "application/octet-stream",
+            path=str(file_path),
+        )
+        await self.file_repo.add(stored)
+        await self.session.commit()
+        await self.session.refresh(stored)
+        return FileRead.model_validate(stored)
+
+    async def get(self, file_id: int, owner_id: int) -> StoredFile:
+        stored = await self.file_repo.get(file_id)
+        if not stored or stored.owner_id != owner_id:
+            raise FileNotFoundError
+        return stored

--- a/tochka_rosta_api/app/services/push.py
+++ b/tochka_rosta_api/app/services/push.py
@@ -1,0 +1,26 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.push import PushToken
+from ..repositories.push import PushTokenRepository
+from ..schemas.push import PushRegisterRequest
+
+
+class PushService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+        self.push_repo = PushTokenRepository(session)
+
+    async def register(self, user_id: int, payload: PushRegisterRequest) -> PushToken:
+        existing = await self.push_repo.get_by_token(payload.token)
+        if existing:
+            existing.user_id = user_id
+            existing.device_type = payload.device_type
+            await self.session.commit()
+            await self.session.refresh(existing)
+            return existing
+
+        token = PushToken(user_id=user_id, token=payload.token, device_type=payload.device_type)
+        await self.push_repo.add(token)
+        await self.session.commit()
+        await self.session.refresh(token)
+        return token

--- a/tochka_rosta_api/app/services/report.py
+++ b/tochka_rosta_api/app/services/report.py
@@ -1,0 +1,33 @@
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..repositories.report import ReportRepository
+from ..schemas.report import ReportRead, ReportUpdate
+
+
+class ReportService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+        self.report_repo = ReportRepository(session)
+
+    async def list_my_reports(self, user_id: int) -> list[ReportRead]:
+        reports = await self.report_repo.list_by_user(user_id)
+        return [ReportRead.model_validate(r) for r in reports]
+
+    async def get(self, report_id: int) -> ReportRead:
+        report = await self.report_repo.get(report_id)
+        if not report:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Report not found")
+        return ReportRead.model_validate(report)
+
+    async def update(self, report_id: int, payload: ReportUpdate) -> ReportRead:
+        report = await self.report_repo.get(report_id)
+        if not report:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Report not found")
+        if payload.status is not None:
+            report.status = payload.status
+        if payload.summary is not None:
+            report.summary = payload.summary
+        await self.session.commit()
+        await self.session.refresh(report)
+        return ReportRead.model_validate(report)

--- a/tochka_rosta_api/app/services/response.py
+++ b/tochka_rosta_api/app/services/response.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.response import Response as ResponseModel, ResponseAnswer as ResponseAnswerModel
+from ..repositories.response import ResponseAnswerRepository, ResponseRepository
+from ..schemas.response import ResponseAnswer, ResponseCreate, ResponseRead, ResponseUpdate
+
+
+class ResponseService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+        self.response_repo = ResponseRepository(session)
+        self.answer_repo = ResponseAnswerRepository(session)
+
+    async def list_for_user(self, user_id: int) -> list[ResponseRead]:
+        responses = await self.response_repo.list_by_user(user_id)
+        return [self._to_schema(r) for r in responses]
+
+    async def create(self, user_id: int, payload: ResponseCreate) -> ResponseRead:
+        response = ResponseModel(user_id=user_id, survey_version_id=payload.survey_version_id)
+        await self.response_repo.add(response)
+        for ans in payload.answers:
+            answer = ResponseAnswerModel(response=response, question_id=ans.question_id, answer=ans.answer)
+            await self.answer_repo.add(answer)
+        await self.session.commit()
+        response = await self.response_repo.get(response.id)
+        return self._to_schema(response)
+
+    async def update(self, response_id: int, user_id: int, payload: ResponseUpdate) -> ResponseRead:
+        response = await self.response_repo.get(response_id)
+        if not response or response.user_id != user_id:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Response not found")
+
+        await self.answer_repo.delete_for_response(response.id)
+        for ans in payload.answers:
+            answer = ResponseAnswerModel(response_id=response.id, question_id=ans.question_id, answer=ans.answer)
+            await self.answer_repo.add(answer)
+        response.submitted_at = datetime.utcnow()
+        await self.session.commit()
+        response = await self.response_repo.get(response.id)
+        return self._to_schema(response)
+
+    def _to_schema(self, response: ResponseModel | None) -> ResponseRead:
+        if response is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Response not found")
+        return ResponseRead(
+            id=response.id,
+            user_id=response.user_id,
+            survey_version_id=response.survey_version_id,
+            submitted_at=response.submitted_at,
+            created_at=response.created_at,
+            updated_at=response.updated_at,
+            answers=[
+                ResponseAnswer(question_id=answer.question_id, answer=answer.answer)
+                for answer in response.answers
+            ],
+        )

--- a/tochka_rosta_api/app/services/survey.py
+++ b/tochka_rosta_api/app/services/survey.py
@@ -1,0 +1,27 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..repositories.survey import (
+    SurveyQuestionRepository,
+    SurveySectionRepository,
+    SurveyVersionRepository,
+)
+from ..schemas.survey import SurveyQuestionRead, SurveySectionRead, SurveyVersionRead
+
+
+class SurveyService:
+    def __init__(self, session: AsyncSession):
+        self.version_repo = SurveyVersionRepository(session)
+        self.section_repo = SurveySectionRepository(session)
+        self.question_repo = SurveyQuestionRepository(session)
+
+    async def get_active_versions(self) -> list[SurveyVersionRead]:
+        versions = await self.version_repo.list_active()
+        return [SurveyVersionRead.model_validate(v) for v in versions]
+
+    async def get_sections(self, version_id: int) -> list[SurveySectionRead]:
+        sections = await self.section_repo.list(version_id=version_id)
+        return [SurveySectionRead.model_validate(s) for s in sections]
+
+    async def get_questions(self, section_id: int) -> list[SurveyQuestionRead]:
+        questions = await self.question_repo.list(section_id=section_id)
+        return [SurveyQuestionRead.model_validate(q) for q in questions]

--- a/tochka_rosta_api/app/services/user.py
+++ b/tochka_rosta_api/app/services/user.py
@@ -1,0 +1,13 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..repositories.user import UserRepository
+from ..schemas.user import UserRead
+
+
+class UserService:
+    def __init__(self, session: AsyncSession):
+        self.user_repo = UserRepository(session)
+
+    async def get_profile(self, user_id: int) -> UserRead | None:
+        user = await self.user_repo.get(user_id)
+        return UserRead.model_validate(user) if user else None

--- a/tochka_rosta_api/requirements.txt
+++ b/tochka_rosta_api/requirements.txt
@@ -1,0 +1,12 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+SQLAlchemy==2.0.25
+asyncpg==0.29.0
+alembic==1.13.1
+pydantic==2.6.1
+pydantic-settings==2.1.0
+python-jose==3.3.0
+passlib[argon2]==1.7.4
+slowapi==0.1.8
+python-multipart==0.0.6
+email-validator==2.1.0.post1


### PR DESCRIPTION
## Summary
- add a FastAPI project skeleton with layered architecture, JWT auth, rate limiting, and core routers
- define SQLAlchemy models, Alembic migration, and repository/service layers for auth, surveys, responses, reports, chat, files, and push tokens
- add Pydantic schemas and requirements for OpenAPI contract coverage

## Testing
- python -m compileall tochka_rosta_api/app

------
https://chatgpt.com/codex/tasks/task_e_68d52db4ecd88329b3e1142282af6742