### PR TITLE
Add S3-backed file upload endpoints with tests

### DIFF
--- a/tochka_rosta_api/app/core/config.py
+++ b/tochka_rosta_api/app/core/config.py
@@ -19,6 +19,12 @@ class Settings(BaseSettings):
 
     file_storage_dir: str = "app/files/storage"
 
+    s3_endpoint: str | None = None
+    s3_access_key: str | None = None
+    s3_secret_key: str | None = None
+    s3_bucket: str = "files"
+    s3_region: str | None = None
+
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
 

--- a/tochka_rosta_api/app/files/storage/s3.py
+++ b/tochka_rosta_api/app/files/storage/s3.py
@@ -1,0 +1,60 @@
+"""S3 storage helper utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import boto3
+
+from ...core.config import get_settings
+
+
+@dataclass(slots=True)
+class S3StorageConfig:
+    endpoint_url: str | None
+    access_key: str | None
+    secret_key: str | None
+    bucket: str
+    region_name: str | None
+
+
+class S3Storage:
+    """A thin wrapper around boto3 S3 client used by the application."""
+
+    def __init__(self, config: S3StorageConfig | None = None):
+        settings = get_settings()
+        cfg = config or S3StorageConfig(
+            endpoint_url=settings.s3_endpoint,
+            access_key=settings.s3_access_key,
+            secret_key=settings.s3_secret_key,
+            bucket=settings.s3_bucket,
+            region_name=settings.s3_region,
+        )
+        self._config = cfg
+        self._client = boto3.client(
+            "s3",
+            endpoint_url=cfg.endpoint_url,
+            aws_access_key_id=cfg.access_key,
+            aws_secret_access_key=cfg.secret_key,
+            region_name=cfg.region_name,
+        )
+
+    @property
+    def bucket(self) -> str:
+        return self._config.bucket
+
+    @property
+    def client(self):
+        return self._client
+
+    def upload(self, data: bytes, key: str, content_type: str) -> None:
+        extra_args: dict[str, Any] = {"ContentType": content_type}
+        self._client.put_object(Bucket=self.bucket, Key=key, Body=data, **extra_args)
+
+    def generate_presigned_url(self, key: str, expires_in: int = 3600) -> str:
+        return self._client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": self.bucket, "Key": key},
+            ExpiresIn=expires_in,
+        )

--- a/tochka_rosta_api/app/models/file.py
+++ b/tochka_rosta_api/app/models/file.py
@@ -5,12 +5,14 @@ from .base import Base, TimestampMixin
 
 
 class StoredFile(TimestampMixin, Base):
-    __tablename__ = "stored_files"
+    __tablename__ = "files"
 
     id: Mapped[int] = mapped_column(primary_key=True)
     owner_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
     filename: Mapped[str] = mapped_column(String(255))
     content_type: Mapped[str] = mapped_column(String(255))
-    path: Mapped[str] = mapped_column(String)
+    size: Mapped[int] = mapped_column()
+    bucket: Mapped[str] = mapped_column(String(255))
+    key: Mapped[str] = mapped_column(String(1024))
 
     owner = relationship("User", back_populates="files")

--- a/tochka_rosta_api/app/routers/files.py
+++ b/tochka_rosta_api/app/routers/files.py
@@ -1,35 +1,40 @@
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
-from fastapi.responses import FileResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.database import get_session
 from ..core.security import get_current_user
 from ..models.user import User
-from ..schemas.file import FileRead
+from ..schemas.file import FileDownloadResponse, FileRead
 from ..services.file import FileService
 
 router = APIRouter(prefix="/files", tags=["files"])
+
+
+def get_file_service(session: AsyncSession = Depends(get_session)) -> FileService:
+    return FileService(session)
 
 
 @router.post("/upload", response_model=FileRead, status_code=status.HTTP_201_CREATED)
 async def upload_file(
     file: UploadFile,
     current_user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session),
+    service: FileService = Depends(get_file_service),
 ) -> FileRead:
-    service = FileService(session)
-    return await service.upload(current_user.id, file)
+    try:
+        return await service.upload(current_user.id, file)
+    except ValueError as exc:  # noqa: PERF203
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
 
-@router.get("/{file_id}")
+@router.get("/{file_id}", response_model=FileDownloadResponse)
 async def get_file(
     file_id: int,
     current_user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session),
-):
-    service = FileService(session)
+    service: FileService = Depends(get_file_service),
+) -> FileDownloadResponse:
     try:
         stored = await service.get(file_id, current_user.id)
     except FileNotFoundError as exc:  # noqa: PERF203
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found") from exc
-    return FileResponse(stored.path, media_type=stored.content_type, filename=stored.filename)
+    url = service.get_download_url(stored)
+    return FileDownloadResponse(url=url)

--- a/tochka_rosta_api/app/schemas/file.py
+++ b/tochka_rosta_api/app/schemas/file.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+from pydantic import BaseModel
+
 from .base import ORMBase
 
 
@@ -8,6 +10,12 @@ class FileRead(ORMBase):
     owner_id: int
     filename: str
     content_type: str
-    path: str
+    size: int
+    bucket: str
+    key: str
     created_at: datetime
     updated_at: datetime
+
+
+class FileDownloadResponse(BaseModel):
+    url: str

--- a/tochka_rosta_api/app/services/file.py
+++ b/tochka_rosta_api/app/services/file.py
@@ -1,43 +1,57 @@
-from pathlib import Path
+from __future__ import annotations
+
+import mimetypes
+from uuid import uuid4
 
 from fastapi import UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..core.config import get_settings
 from ..repositories.file import FileRepository
 from ..schemas.file import FileRead
 from ..models.file import StoredFile
+from ..files.storage.s3 import S3Storage
 
-settings = get_settings()
+ALLOWED_CONTENT_TYPES = {
+    "application/pdf",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+}
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 
 
 class FileService:
-    def __init__(self, session: AsyncSession):
+    def __init__(self, session: AsyncSession, storage: S3Storage | None = None):
         self.session = session
         self.file_repo = FileRepository(session)
-        Path(settings.file_storage_dir).mkdir(parents=True, exist_ok=True)
+        self.storage = storage or S3Storage()
 
     async def upload(self, owner_id: int, upload: UploadFile) -> FileRead:
         filename = upload.filename or "file"
-        file_path = Path(settings.file_storage_dir) / filename
-        counter = 1
-        while file_path.exists():
-            file_path = Path(settings.file_storage_dir) / f"{counter}_{filename}"
-            counter += 1
-
         contents = await upload.read()
         await upload.close()
 
-        with open(file_path, "wb") as buffer:
-            buffer.write(contents)
+        size = len(contents)
+        if size > MAX_FILE_SIZE:
+            raise ValueError("File is too large")
 
-        from ..models.file import StoredFile
+        content_type = upload.content_type
+        if not content_type:
+            guessed, _ = mimetypes.guess_type(filename)
+            content_type = guessed or "application/octet-stream"
+
+        if content_type not in ALLOWED_CONTENT_TYPES:
+            raise ValueError("Unsupported file type")
+
+        key = f"{owner_id}/{uuid4().hex}_{filename}"
+        self.storage.upload(contents, key, content_type)
 
         stored = StoredFile(
             owner_id=owner_id,
             filename=filename,
-            content_type=upload.content_type or "application/octet-stream",
-            path=str(file_path),
+            content_type=content_type,
+            size=size,
+            bucket=self.storage.bucket,
+            key=key,
         )
         await self.file_repo.add(stored)
         await self.session.commit()
@@ -49,3 +63,6 @@ class FileService:
         if not stored or stored.owner_id != owner_id:
             raise FileNotFoundError
         return stored
+
+    def get_download_url(self, stored: StoredFile, expires_in: int = 3600) -> str:
+        return self.storage.generate_presigned_url(stored.key, expires_in)

--- a/tochka_rosta_api/requirements.txt
+++ b/tochka_rosta_api/requirements.txt
@@ -10,3 +10,6 @@ passlib[argon2]==1.7.4
 slowapi==0.1.8
 python-multipart==0.0.6
 email-validator==2.1.0.post1
+boto3==1.34.38
+pytest==8.0.0
+pytest-asyncio==0.23.5

--- a/tochka_rosta_api/tests/test_files.py
+++ b/tochka_rosta_api/tests/test_files.py
@@ -1,0 +1,122 @@
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Generator
+
+import pytest
+from fastapi import Depends
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from tochka_rosta_api.app.core.database import get_session
+from tochka_rosta_api.app.core.security import get_current_user
+from tochka_rosta_api.app.main import app
+from tochka_rosta_api.app.models.base import Base
+from tochka_rosta_api.app.models.user import User
+from tochka_rosta_api.app.routers.files import get_file_service
+from tochka_rosta_api.app.services.file import FileService
+
+
+class FakeS3Storage:
+    def __init__(self) -> None:
+        self.bucket = "test-bucket"
+        self.uploaded: dict[str, dict[str, object]] = {}
+
+    def upload(self, data: bytes, key: str, content_type: str) -> None:
+        self.uploaded[key] = {"data": data, "content_type": content_type}
+
+    def generate_presigned_url(self, key: str, expires_in: int = 3600) -> str:
+        return f"https://fake-s3/{self.bucket}/{key}?expires={expires_in}"
+
+
+@pytest.fixture(scope="session")
+def event_loop() -> Generator[asyncio.AbstractEventLoop, None, None]:
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture()
+def session_factory(
+    event_loop: asyncio.AbstractEventLoop,
+) -> Generator[async_sessionmaker[AsyncSession], None, None]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+
+    async def init_models() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    event_loop.run_until_complete(init_models())
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    event_loop.run_until_complete(engine.dispose())
+
+
+@pytest.fixture()
+def storage() -> FakeS3Storage:
+    return FakeS3Storage()
+
+
+@pytest.fixture()
+def test_user(session_factory: async_sessionmaker[AsyncSession], event_loop: asyncio.AbstractEventLoop) -> User:
+    async def create_user() -> User:
+        async with session_factory() as session:
+            user = User(email="test@example.com", password_hash="hash", role="user")
+            session.add(user)
+            await session.commit()
+            await session.refresh(user)
+            return user
+
+    return event_loop.run_until_complete(create_user())
+
+
+@pytest.fixture()
+def client(
+    session_factory: async_sessionmaker[AsyncSession],
+    storage: FakeS3Storage,
+    test_user: User,
+) -> Generator[TestClient, None, None]:
+    async def override_get_session() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_get_current_user() -> User:
+        return test_user
+
+    def override_get_file_service(
+        session: AsyncSession = Depends(get_session),
+    ) -> FileService:
+        return FileService(session, storage=storage)
+
+    app.dependency_overrides[get_session] = override_get_session
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    app.dependency_overrides[get_file_service] = override_get_file_service
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+    app.dependency_overrides.clear()
+
+
+def test_upload_file_success(client: TestClient, storage: FakeS3Storage) -> None:
+    response = client.post(
+        "/files/upload",
+        files={"file": ("resume.pdf", b"%PDF-1.4", "application/pdf")},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["filename"] == "resume.pdf"
+    assert data["content_type"] == "application/pdf"
+    assert any(key.endswith("resume.pdf") for key in storage.uploaded.keys())
+
+
+def test_get_file_returns_presigned_url(client: TestClient) -> None:
+    upload_response = client.post(
+        "/files/upload",
+        files={"file": ("resume.pdf", b"%PDF-1.4", "application/pdf")},
+    )
+    file_id = upload_response.json()["id"]
+
+    download_response = client.get(f"/files/{file_id}")
+    assert download_response.status_code == 200
+    payload = download_response.json()
+    assert payload["url"].startswith("https://fake-s3/")


### PR DESCRIPTION
## Summary
- add S3 configuration options and storage helper for uploads
- persist uploaded file metadata and return presigned download links
- cover upload and download flows with pytest using a fake S3 storage

## Testing
- pytest *(fails: missing FastAPI dependency in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d531a1f2b08329ba49947a32947bf8