### PR TITLE
feat: add survey form engine with offline support

### DIFF
--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -30,3 +31,7 @@ final dioProvider = Provider<Dio>((ref) {
 
 final authTokenProvider = StateProvider<String?>((ref) => null);
 final refreshTokenProvider = StateProvider<String?>((ref) => null);
+
+final firebaseAnalyticsProvider = Provider<FirebaseAnalytics?>((ref) {
+  return FirebaseAnalytics.instance;
+});

--- a/lib/features/survey/data/datasources/survey_local_data_source.dart
+++ b/lib/features/survey/data/datasources/survey_local_data_source.dart
@@ -1,0 +1,288 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/database/app_database.dart';
+import '../../../../core/providers/app_providers.dart';
+import '../../domain/survey_repository.dart';
+import '../models/survey_models.dart';
+
+class SurveyLocalDataSource {
+  SurveyLocalDataSource(this._db);
+
+  final AppDatabase _db;
+
+  Future<void> cacheSurvey(SurveyVersionModel survey) async {
+    await _db.transaction(() async {
+      await _db.update(_db.surveyVersions).write(
+            const SurveyVersionsCompanion(isActive: Value(false)),
+          );
+      await _db.surveyVersionsDao.upsertSurveyVersion(
+        SurveyVersionsCompanion(
+          id: Value(survey.id),
+          versionNumber: Value(survey.versionNumber),
+          title: Value(survey.title),
+          description: Value(survey.description),
+          isActive: const Value(true),
+        ),
+      );
+
+      for (final section in survey.sections) {
+        await _db.surveySectionsDao.upsertSection(
+          SurveySectionsCompanion(
+            id: Value(section.id),
+            surveyVersionId: Value(section.versionId),
+            title: Value(section.title),
+            description: Value(section.description),
+            position: Value(section.position),
+          ),
+        );
+
+        for (final question in section.questions) {
+          await _db.questionsDao.upsertQuestion(
+            QuestionsCompanion(
+              id: Value(question.id),
+              surveySectionId: Value(question.sectionId),
+              surveyVersionId: Value(question.versionId),
+              questionType: Value(question.type.asJson),
+              text: Value(question.text),
+              helpText: Value(question.helpText),
+              isRequired: Value(question.isRequired),
+              position: Value(question.position),
+              validationRules: Value(
+                jsonEncode({
+                  'scale_min': question.scaleMin,
+                  'scale_max': question.scaleMax,
+                }),
+              ),
+            ),
+          );
+
+          for (final option in question.options) {
+            await _db.questionOptionsDao.upsertOption(
+              QuestionOptionsCompanion(
+                id: Value(option.id),
+                questionId: Value(question.id),
+                value: Value(option.value),
+                label: Value(option.label),
+                position: Value(option.position),
+                isDefault: Value(option.isDefault),
+              ),
+            );
+          }
+        }
+      }
+    });
+  }
+
+  Future<SurveyVersionModel?> readActiveSurvey() async {
+    final version = await _db.surveyVersionsDao.getActiveVersion();
+    if (version == null) {
+      return null;
+    }
+    return _mapSurveyVersion(version);
+  }
+
+  Future<SurveyVersionModel?> readSurveyById(String versionId) async {
+    final query = await (_db.select(_db.surveyVersions)
+          ..where((tbl) => tbl.id.equals(versionId)))
+        .getSingleOrNull();
+    if (query == null) {
+      return null;
+    }
+    return _mapSurveyVersion(query);
+  }
+
+  Future<Map<String, dynamic>> loadSavedAnswers(
+    String surveyVersionId,
+    String userId,
+  ) async {
+    final responses = await (_db.select(_db.responses)
+          ..where(
+            (tbl) =>
+                tbl.surveyVersionId.equals(surveyVersionId) &
+                tbl.userId.equals(userId),
+          ))
+        .get();
+    final answers = <String, dynamic>{};
+    for (final response in responses) {
+      try {
+        answers[response.questionId] = jsonDecode(response.answer);
+      } catch (_) {
+        answers[response.questionId] = response.answer;
+      }
+    }
+    return answers;
+  }
+
+  Future<void> saveAnswer({
+    required String surveyVersionId,
+    required String questionId,
+    required String userId,
+    required dynamic answer,
+    DateTime? answeredAt,
+  }) async {
+    await _ensureUser(userId);
+    await _db.responsesDao.upsertResponse(
+      ResponsesCompanion(
+        id: Value('$userId-$questionId'),
+        questionId: Value(questionId),
+        userId: Value(userId),
+        surveyVersionId: Value(surveyVersionId),
+        answer: Value(jsonEncode(answer)),
+        answeredAt: Value(answeredAt ?? DateTime.now()),
+        isSynced: const Value(false),
+        updatedAt: Value(DateTime.now()),
+      ),
+    );
+  }
+
+  Future<List<SurveyAnswerPayload>> pendingAnswers(String userId) async {
+    final pending = await (_db.select(_db.responses)
+          ..where(
+            (tbl) => tbl.userId.equals(userId) & tbl.isSynced.equals(false),
+          ))
+        .get();
+    return pending
+        .map(
+          (response) => SurveyAnswerPayload(
+            id: response.id,
+            questionId: response.questionId,
+            surveyVersionId: response.surveyVersionId,
+            userId: response.userId,
+            answer: response.answer,
+            answeredAt: response.answeredAt,
+            isSynced: response.isSynced,
+          ),
+        )
+        .toList();
+  }
+
+  Future<void> markAnswerSynced(String responseId) async {
+    await (_db.update(_db.responses)..where((tbl) => tbl.id.equals(responseId))).write(
+      ResponsesCompanion(
+        isSynced: const Value(true),
+        updatedAt: Value(DateTime.now()),
+      ),
+    );
+  }
+
+  Future<SurveyProgressModel> getProgress(
+    String surveyVersionId,
+    String userId,
+  ) async {
+    final progress = await _db.responsesDao.getSurveyProgress(
+      surveyVersionId,
+      userId,
+    );
+    return SurveyProgressModel(
+      totalQuestions: progress.totalQuestions,
+      answeredQuestions: progress.answeredQuestions,
+    );
+  }
+
+  Future<SurveyVersionModel> _mapSurveyVersion(SurveyVersion version) async {
+    final sections = await _db.surveySectionsDao.sectionsByVersion(version.id);
+    final questions = await _db.questionsDao.questionsForVersion(version.id);
+
+    final sectionModels = <SurveySectionModel>[];
+    for (final section in sections..sort((a, b) => a.position.compareTo(b.position))) {
+      final sectionQuestions = questions
+          .where((q) => q.surveySectionId == section.id)
+          .toList()
+        ..sort((a, b) => a.position.compareTo(b.position));
+      final questionModels = <SurveyQuestionModel>[];
+
+      for (final question in sectionQuestions) {
+        final optionEntities = await _db.questionOptionsDao.optionsForQuestion(question.id);
+        final options = optionEntities
+            .map(
+              (option) => SurveyOptionModel(
+                id: option.id,
+                value: option.value,
+                label: option.label,
+                position: option.position,
+                isDefault: option.isDefault,
+              ),
+            )
+            .toList()
+          ..sort((a, b) => a.position.compareTo(b.position));
+
+        final validation = _parseValidation(question.validationRules);
+        questionModels.add(
+          SurveyQuestionModel(
+            id: question.id,
+            sectionId: question.surveySectionId,
+            versionId: question.surveyVersionId,
+            type: SurveyQuestionType.fromJson(question.questionType),
+            text: question.text,
+            helpText: question.helpText,
+            isRequired: question.isRequired,
+            position: question.position,
+            options: options,
+            scaleMin: validation['scale_min'] as int? ?? 0,
+            scaleMax: validation['scale_max'] as int? ?? 10,
+          ),
+        );
+      }
+
+      sectionModels.add(
+        SurveySectionModel(
+          id: section.id,
+          versionId: section.surveyVersionId,
+          title: section.title,
+          description: section.description,
+          position: section.position,
+          timeLimitSeconds: 180,
+          questions: questionModels,
+        ),
+      );
+    }
+
+    return SurveyVersionModel(
+      id: version.id,
+      versionNumber: version.versionNumber,
+      title: version.title,
+      description: version.description,
+      isActive: version.isActive,
+      sections: sectionModels,
+    );
+  }
+
+  Map<String, dynamic> _parseValidation(String? json) {
+    if (json == null || json.isEmpty) {
+      return {};
+    }
+    try {
+      final decoded = jsonDecode(json);
+      if (decoded is Map<String, dynamic>) {
+        return decoded;
+      }
+      if (decoded is Map) {
+        return decoded.map((key, value) => MapEntry('$key', value));
+      }
+    } catch (_) {
+      // ignore parsing errors and return empty config
+    }
+    return {};
+  }
+
+  Future<void> _ensureUser(String userId) async {
+    final existing = await _db.usersDao.fetchUser(userId);
+    if (existing != null) {
+      return;
+    }
+    await _db.usersDao.createOrUpdateUser(
+      UsersCompanion(
+        id: Value(userId),
+        status: const Value('active'),
+      ),
+    );
+  }
+}
+
+final surveyLocalDataSourceProvider = Provider<SurveyLocalDataSource>((ref) {
+  final db = ref.watch(appDatabaseProvider);
+  return SurveyLocalDataSource(db);
+});

--- a/lib/features/survey/data/datasources/survey_remote_data_source.dart
+++ b/lib/features/survey/data/datasources/survey_remote_data_source.dart
@@ -1,0 +1,29 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/providers/app_providers.dart';
+import '../models/survey_models.dart';
+
+class SurveyRemoteDataSource {
+  SurveyRemoteDataSource(this._dio);
+
+  final Dio _dio;
+
+  Future<SurveyVersionModel> fetchActiveSurvey() async {
+    final response = await _dio.get<dynamic>('/surveys/active');
+    final data = response.data as Map<String, dynamic>;
+    return SurveyVersionModel.fromJson(data);
+  }
+
+  Future<void> submitResponse(SurveyAnswerPayload payload) async {
+    await _dio.post<dynamic>(
+      '/surveys/${payload.surveyVersionId}/questions/${payload.questionId}/responses',
+      data: payload.toRemotePayload(),
+    );
+  }
+}
+
+final surveyRemoteDataSourceProvider = Provider<SurveyRemoteDataSource>((ref) {
+  final dio = ref.watch(dioProvider);
+  return SurveyRemoteDataSource(dio);
+});

--- a/lib/features/survey/data/models/survey_models.dart
+++ b/lib/features/survey/data/models/survey_models.dart
@@ -1,0 +1,272 @@
+import 'dart:convert';
+
+enum SurveyQuestionType { scale, checkbox, radio, text;
+
+  factory SurveyQuestionType.fromJson(String value) {
+    switch (value) {
+      case 'scale':
+        return SurveyQuestionType.scale;
+      case 'checkbox':
+        return SurveyQuestionType.checkbox;
+      case 'radio':
+        return SurveyQuestionType.radio;
+      case 'text':
+        return SurveyQuestionType.text;
+      default:
+        throw ArgumentError('Unsupported question type: $value');
+    }
+  }
+
+  String get asJson {
+    switch (this) {
+      case SurveyQuestionType.scale:
+        return 'scale';
+      case SurveyQuestionType.checkbox:
+        return 'checkbox';
+      case SurveyQuestionType.radio:
+        return 'radio';
+      case SurveyQuestionType.text:
+        return 'text';
+    }
+  }
+}
+
+class SurveyOptionModel {
+  const SurveyOptionModel({
+    required this.id,
+    required this.value,
+    required this.label,
+    required this.position,
+    this.isDefault = false,
+  });
+
+  factory SurveyOptionModel.fromJson(Map<String, dynamic> json) {
+    return SurveyOptionModel(
+      id: json['id'] as String,
+      value: json['value'] as String,
+      label: json['label'] as String,
+      position: json['position'] as int? ?? 0,
+      isDefault: json['is_default'] as bool? ?? false,
+    );
+  }
+
+  final String id;
+  final String value;
+  final String label;
+  final int position;
+  final bool isDefault;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'value': value,
+      'label': label,
+      'position': position,
+      'is_default': isDefault,
+    };
+  }
+}
+
+class SurveyQuestionModel {
+  const SurveyQuestionModel({
+    required this.id,
+    required this.sectionId,
+    required this.versionId,
+    required this.type,
+    required this.text,
+    this.helpText,
+    this.isRequired = false,
+    this.position = 0,
+    this.options = const [],
+    this.scaleMin = 0,
+    this.scaleMax = 10,
+  });
+
+  factory SurveyQuestionModel.fromJson(Map<String, dynamic> json) {
+    return SurveyQuestionModel(
+      id: json['id'] as String,
+      sectionId: json['section_id'] as String,
+      versionId: json['version_id'] as String,
+      type: SurveyQuestionType.fromJson(json['type'] as String),
+      text: json['text'] as String,
+      helpText: json['help_text'] as String?,
+      isRequired: json['is_required'] as bool? ?? false,
+      position: json['position'] as int? ?? 0,
+      options: (json['options'] as List<dynamic>? ?? [])
+          .map((e) => SurveyOptionModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      scaleMin: json['scale_min'] as int? ?? 0,
+      scaleMax: json['scale_max'] as int? ?? 10,
+    );
+  }
+
+  final String id;
+  final String sectionId;
+  final String versionId;
+  final SurveyQuestionType type;
+  final String text;
+  final String? helpText;
+  final bool isRequired;
+  final int position;
+  final List<SurveyOptionModel> options;
+  final int scaleMin;
+  final int scaleMax;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'section_id': sectionId,
+      'version_id': versionId,
+      'type': type.asJson,
+      'text': text,
+      'help_text': helpText,
+      'is_required': isRequired,
+      'position': position,
+      'options': options.map((e) => e.toJson()).toList(),
+      'scale_min': scaleMin,
+      'scale_max': scaleMax,
+    };
+  }
+}
+
+class SurveySectionModel {
+  const SurveySectionModel({
+    required this.id,
+    required this.versionId,
+    required this.title,
+    this.description,
+    this.position = 0,
+    this.timeLimitSeconds,
+    this.questions = const [],
+  });
+
+  factory SurveySectionModel.fromJson(Map<String, dynamic> json) {
+    return SurveySectionModel(
+      id: json['id'] as String,
+      versionId: json['version_id'] as String,
+      title: json['title'] as String,
+      description: json['description'] as String?,
+      position: json['position'] as int? ?? 0,
+      timeLimitSeconds: json['time_limit_seconds'] as int?,
+      questions: (json['questions'] as List<dynamic>? ?? [])
+          .map((e) => SurveyQuestionModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  final String id;
+  final String versionId;
+  final String title;
+  final String? description;
+  final int position;
+  final int? timeLimitSeconds;
+  final List<SurveyQuestionModel> questions;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'version_id': versionId,
+      'title': title,
+      'description': description,
+      'position': position,
+      'time_limit_seconds': timeLimitSeconds,
+      'questions': questions.map((e) => e.toJson()).toList(),
+    };
+  }
+}
+
+class SurveyVersionModel {
+  const SurveyVersionModel({
+    required this.id,
+    required this.versionNumber,
+    required this.title,
+    this.description,
+    this.isActive = false,
+    this.sections = const [],
+  });
+
+  factory SurveyVersionModel.fromJson(Map<String, dynamic> json) {
+    return SurveyVersionModel(
+      id: json['id'] as String,
+      versionNumber: json['version'] as int,
+      title: json['title'] as String,
+      description: json['description'] as String?,
+      isActive: json['is_active'] as bool? ?? false,
+      sections: (json['sections'] as List<dynamic>? ?? [])
+          .map((e) => SurveySectionModel.fromJson(e as Map<String, dynamic>))
+          .toList()
+        ..sort((a, b) => a.position.compareTo(b.position)),
+    );
+  }
+
+  final String id;
+  final int versionNumber;
+  final String title;
+  final String? description;
+  final bool isActive;
+  final List<SurveySectionModel> sections;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'version': versionNumber,
+      'title': title,
+      'description': description,
+      'is_active': isActive,
+      'sections': sections.map((e) => e.toJson()).toList(),
+    };
+  }
+}
+
+class SurveyAnswerPayload {
+  const SurveyAnswerPayload({
+    required this.questionId,
+    required this.surveyVersionId,
+    required this.answer,
+    required this.userId,
+    required this.id,
+    this.answeredAt,
+    this.isSynced = false,
+  });
+
+  factory SurveyAnswerPayload.fromDatabase(Map<String, dynamic> row) {
+    return SurveyAnswerPayload(
+      id: row['id'] as String,
+      questionId: row['question_id'] as String,
+      surveyVersionId: row['survey_version_id'] as String,
+      userId: row['user_id'] as String,
+      answer: row['answer'] as String,
+      answeredAt: row['answered_at'] as DateTime?,
+      isSynced: row['is_synced'] == 1 || row['is_synced'] == true,
+    );
+  }
+
+  final String id;
+  final String questionId;
+  final String surveyVersionId;
+  final String userId;
+  final String answer;
+  final DateTime? answeredAt;
+  final bool isSynced;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'question_id': questionId,
+      'survey_version_id': surveyVersionId,
+      'user_id': userId,
+      'answer': answer,
+      'answered_at': answeredAt?.toIso8601String(),
+      'is_synced': isSynced,
+    };
+  }
+
+  Map<String, dynamic> toRemotePayload() {
+    return {
+      'question_id': questionId,
+      'survey_version_id': surveyVersionId,
+      'answer': jsonDecode(answer),
+      'answered_at': answeredAt?.toIso8601String(),
+    };
+  }
+}

--- a/lib/features/survey/data/repositories/survey_repository_impl.dart
+++ b/lib/features/survey/data/repositories/survey_repository_impl.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/survey_repository.dart';
+import '../datasources/survey_local_data_source.dart';
+import '../datasources/survey_remote_data_source.dart';
+import '../models/survey_models.dart';
+
+class SurveyRepositoryImpl implements SurveyRepository {
+  SurveyRepositoryImpl(this._remote, this._local);
+
+  final SurveyRemoteDataSource _remote;
+  final SurveyLocalDataSource _local;
+  SurveyVersionModel? _memoryCache;
+
+  @override
+  Future<SurveyVersionModel> fetchActiveSurvey({bool forceRefresh = false}) async {
+    if (!forceRefresh && _memoryCache != null) {
+      return _memoryCache!;
+    }
+
+    try {
+      final survey = await _remote.fetchActiveSurvey();
+      await _local.cacheSurvey(survey);
+      _memoryCache = survey;
+      return survey;
+    } catch (_) {
+      final cached = await _local.readActiveSurvey();
+      if (cached != null) {
+        _memoryCache = cached;
+        return cached;
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<Map<String, dynamic>> loadSavedAnswers(
+    String surveyVersionId,
+    String userId,
+  ) {
+    return _local.loadSavedAnswers(surveyVersionId, userId);
+  }
+
+  @override
+  Future<void> saveAnswer({
+    required String surveyVersionId,
+    required String questionId,
+    required String userId,
+    required dynamic answer,
+    DateTime? answeredAt,
+  }) {
+    return _local.saveAnswer(
+      surveyVersionId: surveyVersionId,
+      questionId: questionId,
+      userId: userId,
+      answer: answer,
+      answeredAt: answeredAt,
+    );
+  }
+
+  @override
+  Future<List<SurveyAnswerPayload>> pendingAnswers(String userId) {
+    return _local.pendingAnswers(userId);
+  }
+
+  @override
+  Future<void> markAnswerSynced(String responseId) {
+    return _local.markAnswerSynced(responseId);
+  }
+
+  @override
+  Future<SurveyProgressModel> getProgress(String surveyVersionId, String userId) {
+    return _local.getProgress(surveyVersionId, userId);
+  }
+}
+
+final surveyRepositoryProvider = Provider<SurveyRepository>((ref) {
+  final remote = ref.watch(surveyRemoteDataSourceProvider);
+  final local = ref.watch(surveyLocalDataSourceProvider);
+  return SurveyRepositoryImpl(remote, local);
+});

--- a/lib/features/survey/domain/survey_repository.dart
+++ b/lib/features/survey/domain/survey_repository.dart
@@ -1,0 +1,44 @@
+import '../data/models/survey_models.dart';
+
+class SurveyProgressModel {
+  const SurveyProgressModel({
+    required this.totalQuestions,
+    required this.answeredQuestions,
+  });
+
+  final int totalQuestions;
+  final int answeredQuestions;
+
+  double get completionRate {
+    if (totalQuestions == 0) {
+      return 0;
+    }
+    return answeredQuestions / totalQuestions;
+  }
+}
+
+abstract class SurveyRepository {
+  Future<SurveyVersionModel> fetchActiveSurvey({bool forceRefresh = false});
+
+  Future<Map<String, dynamic>> loadSavedAnswers(
+    String surveyVersionId,
+    String userId,
+  );
+
+  Future<void> saveAnswer({
+    required String surveyVersionId,
+    required String questionId,
+    required String userId,
+    required dynamic answer,
+    DateTime? answeredAt,
+  });
+
+  Future<List<SurveyAnswerPayload>> pendingAnswers(String userId);
+
+  Future<void> markAnswerSynced(String responseId);
+
+  Future<SurveyProgressModel> getProgress(
+    String surveyVersionId,
+    String userId,
+  );
+}

--- a/lib/features/survey/presentation/controllers/survey_controller.dart
+++ b/lib/features/survey/presentation/controllers/survey_controller.dart
@@ -1,0 +1,354 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:firebase_analytics/firebase_analytics.dart';
+
+import '../../../../core/providers/app_providers.dart';
+import '../../data/models/survey_models.dart';
+import '../../domain/survey_repository.dart';
+import 'survey_sync_service.dart';
+
+class SurveyState {
+  const SurveyState({
+    required this.survey,
+    required this.currentSectionIndex,
+    required this.currentQuestionIndex,
+    required this.answers,
+    required this.remainingTime,
+    this.isSaving = false,
+    this.validationError,
+  });
+
+  factory SurveyState.initial() => SurveyState(
+        survey: const AsyncValue.loading(),
+        currentSectionIndex: 0,
+        currentQuestionIndex: 0,
+        answers: const {},
+        remainingTime: Duration.zero,
+      );
+
+  final AsyncValue<SurveyVersionModel> survey;
+  final int currentSectionIndex;
+  final int currentQuestionIndex;
+  final Map<String, dynamic> answers;
+  final Duration remainingTime;
+  final bool isSaving;
+  final String? validationError;
+
+  SurveyQuestionModel? get currentQuestion {
+    final version = survey.valueOrNull;
+    if (version == null) return null;
+    if (currentSectionIndex >= version.sections.length) return null;
+    final section = version.sections[currentSectionIndex];
+    if (currentQuestionIndex >= section.questions.length) return null;
+    return section.questions[currentQuestionIndex];
+  }
+
+  SurveySectionModel? get currentSection {
+    final version = survey.valueOrNull;
+    if (version == null) return null;
+    if (currentSectionIndex >= version.sections.length) return null;
+    return version.sections[currentSectionIndex];
+  }
+
+  int get totalQuestions {
+    final version = survey.valueOrNull;
+    if (version == null) return 0;
+    return version.sections.fold<int>(
+      0,
+      (previousValue, element) => previousValue + element.questions.length,
+    );
+  }
+
+  int get answeredQuestions => answers.length;
+
+  double get progress {
+    final total = totalQuestions;
+    if (total == 0) {
+      return 0;
+    }
+    return answeredQuestions / total;
+  }
+
+  SurveyState copyWith({
+    AsyncValue<SurveyVersionModel>? survey,
+    int? currentSectionIndex,
+    int? currentQuestionIndex,
+    Map<String, dynamic>? answers,
+    Duration? remainingTime,
+    bool? isSaving,
+    String? validationError,
+    bool clearValidationError = false,
+  }) {
+    return SurveyState(
+      survey: survey ?? this.survey,
+      currentSectionIndex: currentSectionIndex ?? this.currentSectionIndex,
+      currentQuestionIndex: currentQuestionIndex ?? this.currentQuestionIndex,
+      answers: answers ?? this.answers,
+      remainingTime: remainingTime ?? this.remainingTime,
+      isSaving: isSaving ?? this.isSaving,
+      validationError: clearValidationError ? null : validationError ?? this.validationError,
+    );
+  }
+}
+
+class SurveyController extends StateNotifier<SurveyState> {
+  SurveyController(
+    this._repository,
+    this._syncService,
+    this._analytics,
+    this._userId,
+  ) : super(SurveyState.initial());
+
+  final SurveyRepository _repository;
+  final SurveySyncService? _syncService;
+  final FirebaseAnalytics? _analytics;
+  final String _userId;
+
+  Timer? _timer;
+
+  Future<void> loadSurvey() async {
+    state = state.copyWith(survey: const AsyncValue.loading());
+    try {
+      final survey = await _repository.fetchActiveSurvey();
+      final savedAnswers = await _repository.loadSavedAnswers(survey.id, _userId);
+
+      if (survey.sections.isEmpty) {
+        state = state.copyWith(
+          survey: AsyncValue.data(survey),
+          answers: Map<String, dynamic>.from(savedAnswers),
+          currentSectionIndex: 0,
+          currentQuestionIndex: 0,
+          remainingTime: Duration.zero,
+          clearValidationError: true,
+        );
+        await _analytics?.logEvent(name: 'survey_start', parameters: {'survey_id': survey.id});
+        unawaited(_syncService?.syncPendingResponses(_userId));
+        return;
+      }
+
+      var sectionIndex = 0;
+      var questionIndex = 0;
+      bool located = false;
+      for (var i = 0; i < survey.sections.length; i++) {
+        final section = survey.sections[i];
+        if (section.questions.isEmpty) {
+          continue;
+        }
+        for (var j = 0; j < section.questions.length; j++) {
+          final question = section.questions[j];
+          if (!savedAnswers.containsKey(question.id)) {
+            sectionIndex = i;
+            questionIndex = j;
+            located = true;
+            break;
+          }
+        }
+        if (located) {
+          break;
+        }
+      }
+
+      if (!located) {
+        for (var i = survey.sections.length - 1; i >= 0; i--) {
+          final section = survey.sections[i];
+          if (section.questions.isNotEmpty) {
+            sectionIndex = i;
+            questionIndex = section.questions.length - 1;
+            break;
+          }
+        }
+      }
+
+      final targetSection = survey.sections[sectionIndex];
+      state = state.copyWith(
+        survey: AsyncValue.data(survey),
+        answers: Map<String, dynamic>.from(savedAnswers),
+        currentSectionIndex: sectionIndex,
+        currentQuestionIndex: questionIndex,
+        remainingTime: _initialSectionDuration(targetSection),
+        clearValidationError: true,
+      );
+      _startTimer();
+      await _analytics?.logEvent(name: 'survey_start', parameters: {'survey_id': survey.id});
+      unawaited(_syncService?.syncPendingResponses(_userId));
+    } catch (error, stackTrace) {
+      state = state.copyWith(survey: AsyncValue.error(error, stackTrace));
+    }
+  }
+
+  Future<void> saveAnswer(dynamic answer) async {
+    final survey = state.survey.valueOrNull;
+    final question = state.currentQuestion;
+    if (survey == null || question == null) {
+      return;
+    }
+    state = state.copyWith(isSaving: true, clearValidationError: true);
+    final updatedAnswers = Map<String, dynamic>.from(state.answers)
+      ..[question.id] = answer;
+    try {
+      await _repository.saveAnswer(
+        surveyVersionId: survey.id,
+        questionId: question.id,
+        userId: _userId,
+        answer: answer,
+      );
+      state = state.copyWith(
+        isSaving: false,
+        answers: updatedAnswers,
+        clearValidationError: true,
+      );
+      unawaited(_syncService?.syncPendingResponses(_userId));
+    } catch (error) {
+      updatedAnswers.remove(question.id);
+      state = state.copyWith(isSaving: false, answers: state.answers);
+      rethrow;
+    }
+  }
+
+  Future<void> nextQuestion({bool triggeredByTimer = false}) async {
+    final survey = state.survey.valueOrNull;
+    final section = state.currentSection;
+    final question = state.currentQuestion;
+    if (survey == null || section == null || question == null) {
+      return;
+    }
+
+    if (!triggeredByTimer && !_hasAnswer(question)) {
+      state = state.copyWith(validationError: 'Пожалуйста, ответьте на вопрос.');
+      return;
+    }
+
+    final isLastQuestionInSection =
+        state.currentQuestionIndex >= section.questions.length - 1;
+    final isLastSection = state.currentSectionIndex >= survey.sections.length - 1;
+    final isLastQuestionInSurvey =
+        isLastQuestionInSection && isLastSection;
+
+    if (isLastQuestionInSurvey) {
+      await _analytics?.logEvent(
+        name: 'survey_complete',
+        parameters: {'survey_id': survey.id},
+      );
+      _timer?.cancel();
+      state = state.copyWith(validationError: null);
+      return;
+    }
+
+    if (isLastQuestionInSection) {
+      await _analytics?.logEvent(
+        name: 'survey_section_complete',
+        parameters: {
+          'survey_id': survey.id,
+          'section_id': section.id,
+        },
+      );
+      final nextSectionIndex = state.currentSectionIndex + 1;
+      if (nextSectionIndex < survey.sections.length) {
+        state = state.copyWith(
+          currentSectionIndex: nextSectionIndex,
+          currentQuestionIndex: 0,
+          validationError: null,
+          remainingTime: _initialSectionDuration(survey.sections[nextSectionIndex]),
+        );
+        _startTimer();
+      }
+    } else {
+      state = state.copyWith(
+        currentQuestionIndex: state.currentQuestionIndex + 1,
+        validationError: null,
+      );
+    }
+  }
+
+  void previousQuestion() {
+    final survey = state.survey.valueOrNull;
+    if (survey == null) return;
+    if (state.currentQuestionIndex > 0) {
+      state = state.copyWith(
+        currentQuestionIndex: state.currentQuestionIndex - 1,
+        validationError: null,
+      );
+      return;
+    }
+    if (state.currentSectionIndex > 0) {
+      final prevSectionIndex = state.currentSectionIndex - 1;
+      final prevSection = survey.sections[prevSectionIndex];
+      state = state.copyWith(
+        currentSectionIndex: prevSectionIndex,
+        currentQuestionIndex: prevSection.questions.length - 1,
+        remainingTime: _initialSectionDuration(prevSection),
+        validationError: null,
+      );
+      _startTimer();
+    }
+  }
+
+  Future<void> continueLater() async {
+    _timer?.cancel();
+    await _syncService?.syncPendingResponses(_userId);
+  }
+
+  void disposeController() {
+    _timer?.cancel();
+  }
+
+  bool _hasAnswer(SurveyQuestionModel question) {
+    final answer = state.answers[question.id];
+    if (answer == null) {
+      return false;
+    }
+    switch (question.type) {
+      case SurveyQuestionType.checkbox:
+        return answer is Iterable && answer.isNotEmpty;
+      case SurveyQuestionType.text:
+        return answer is String && answer.trim().isNotEmpty;
+      default:
+        return true;
+    }
+  }
+
+  Duration _initialSectionDuration(SurveySectionModel section) {
+    final seconds = section.timeLimitSeconds ?? 180;
+    return Duration(seconds: seconds);
+  }
+
+  void _startTimer() {
+    _timer?.cancel();
+    final section = state.currentSection;
+    if (section == null) {
+      return;
+    }
+    var remaining = section.timeLimitSeconds ?? 180;
+    state = state.copyWith(remainingTime: Duration(seconds: remaining));
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      remaining -= 1;
+      if (remaining <= 0) {
+        timer.cancel();
+        unawaited(nextQuestion(triggeredByTimer: true));
+      } else {
+        state = state.copyWith(remainingTime: Duration(seconds: remaining));
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    disposeController();
+    super.dispose();
+  }
+}
+
+final surveyUserIdProvider = Provider<String>((ref) => 'local-user');
+
+final surveyControllerProvider =
+    StateNotifierProvider<SurveyController, SurveyState>((ref) {
+  final repository = ref.watch(surveyRepositoryProvider);
+  final syncService = ref.watch(surveySyncServiceProvider);
+  final analytics = ref.watch(firebaseAnalyticsProvider);
+  final userId = ref.watch(surveyUserIdProvider);
+  final controller = SurveyController(repository, syncService, analytics, userId);
+  ref.onDispose(controller.disposeController);
+  unawaited(controller.loadSurvey());
+  return controller;
+});

--- a/lib/features/survey/presentation/controllers/survey_sync_service.dart
+++ b/lib/features/survey/presentation/controllers/survey_sync_service.dart
@@ -1,0 +1,51 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/datasources/survey_remote_data_source.dart';
+import '../../data/models/survey_models.dart';
+import '../../domain/survey_repository.dart';
+
+class SurveySyncService {
+  SurveySyncService(this._repository, this._remoteDataSource);
+
+  final SurveyRepository _repository;
+  final SurveyRemoteDataSource _remoteDataSource;
+
+  Future<void> syncPendingResponses(String userId) async {
+    final pending = await _repository.pendingAnswers(userId);
+    for (final response in pending) {
+      await _syncWithBackoff(response);
+    }
+  }
+
+  Future<void> _syncWithBackoff(SurveyAnswerPayload response) async {
+    const maxAttempts = 5;
+    var attempt = 0;
+    var delay = const Duration(milliseconds: 500);
+
+    while (attempt < maxAttempts) {
+      try {
+        await _remoteDataSource.submitResponse(response);
+        await _repository.markAnswerSynced(response.id);
+        return;
+      } catch (_) {
+        attempt += 1;
+        if (attempt >= maxAttempts) {
+          return;
+        }
+        await Future<void>.delayed(delay);
+        final nextDelay = delay * 2;
+        delay = nextDelay > const Duration(seconds: 30)
+            ? const Duration(seconds: 30)
+            : nextDelay;
+      }
+    }
+  }
+}
+
+final surveySyncServiceProvider = Provider<SurveySyncService?>((ref) {
+  final repository = ref.watch(surveyRepositoryProvider);
+  final remote = ref.watch(surveyRemoteDataSourceProvider);
+  return SurveySyncService(repository, remote);
+});

--- a/lib/features/survey/presentation/pages/survey_page.dart
+++ b/lib/features/survey/presentation/pages/survey_page.dart
@@ -1,21 +1,182 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/localization/l10n.dart';
+import '../controllers/survey_controller.dart';
+import '../widgets/survey_question_card.dart';
 
-class SurveyPage extends StatelessWidget {
+class SurveyPage extends ConsumerWidget {
   const SurveyPage({super.key});
 
   static const routeName = 'survey';
   static const routePath = '/survey';
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(surveyControllerProvider);
+    final controller = ref.read(surveyControllerProvider.notifier);
     final l10n = AppLocalizations.of(context);
+
     return Scaffold(
-      appBar: AppBar(title: Text(l10n.surveyTitle)),
-      body: const Center(
-        child: Text('Конструктор опросов находится в разработке.'),
+      appBar: AppBar(
+        title: Text(state.survey.valueOrNull?.title ?? l10n.surveyTitle),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: _TimerBadge(remaining: state.remainingTime),
+          ),
+        ],
       ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: state.survey.when(
+            data: (survey) {
+              final section = state.currentSection;
+              final question = state.currentQuestion;
+              if (survey.sections.isEmpty || section == null || question == null) {
+                return const Center(child: Text('Нет доступных вопросов.'));
+              }
+
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    section.title,
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
+                  if (section.description != null && section.description!.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8),
+                      child: Text(section.description!),
+                    ),
+                  const SizedBox(height: 12),
+                  LinearProgressIndicator(value: state.progress),
+                  const SizedBox(height: 8),
+                  Text(
+                    '${state.answeredQuestions}/${state.totalQuestions} вопросов',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                  const SizedBox(height: 16),
+                  Expanded(
+                    child: SingleChildScrollView(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          SurveyQuestionCard(
+                            question: question,
+                            answer: state.answers[question.id],
+                            onChanged: (value) {
+                              controller.saveAnswer(value);
+                            },
+                          ),
+                          if (state.validationError != null)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 8),
+                              child: Text(
+                                state.validationError!,
+                                style: TextStyle(color: Theme.of(context).colorScheme.error),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  Row(
+                    children: [
+                      TextButton(
+                        onPressed: () async {
+                          await controller.continueLater();
+                          if (context.mounted) {
+                            Navigator.of(context).pop();
+                          }
+                        },
+                        child: const Text('Продолжить позже'),
+                      ),
+                      const Spacer(),
+                      OutlinedButton(
+                        onPressed: state.currentSectionIndex == 0 && state.currentQuestionIndex == 0
+                            ? null
+                            : controller.previousQuestion,
+                        child: const Text('Назад'),
+                      ),
+                      const SizedBox(width: 12),
+                      ElevatedButton(
+                        onPressed: state.isSaving
+                            ? null
+                            : () {
+                                controller.nextQuestion();
+                              },
+                        child: state.isSaving
+                            ? const SizedBox(
+                                height: 16,
+                                width: 16,
+                                child: CircularProgressIndicator(strokeWidth: 2),
+                              )
+                            : const Text('Далее'),
+                      ),
+                    ],
+                  ),
+                ],
+              );
+            },
+            error: (error, _) => _ErrorState(
+              message: error.toString(),
+              onRetry: controller.loadSurvey,
+            ),
+            loading: () => const Center(child: CircularProgressIndicator()),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            'Не удалось загрузить анкету',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          Text(message, textAlign: TextAlign.center),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: onRetry,
+            child: const Text('Повторить'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TimerBadge extends StatelessWidget {
+  const _TimerBadge({required this.remaining});
+
+  final Duration remaining;
+
+  @override
+  Widget build(BuildContext context) {
+    final minutes = remaining.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final seconds = remaining.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Text('$minutes:$seconds'),
     );
   }
 }

--- a/lib/features/survey/presentation/widgets/survey_question_card.dart
+++ b/lib/features/survey/presentation/widgets/survey_question_card.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/material.dart';
+
+import '../../data/models/survey_models.dart';
+
+class SurveyQuestionCard extends StatelessWidget {
+  const SurveyQuestionCard({
+    super.key,
+    required this.question,
+    required this.answer,
+    required this.onChanged,
+  });
+
+  final SurveyQuestionModel question;
+  final dynamic answer;
+  final ValueChanged<dynamic> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 12),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              question.text,
+              style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            if (question.helpText != null && question.helpText!.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text(
+                question.helpText!,
+                style: theme.textTheme.bodyMedium,
+              ),
+            ],
+            const SizedBox(height: 16),
+            _buildQuestionBody(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildQuestionBody() {
+    switch (question.type) {
+      case SurveyQuestionType.scale:
+        return _ScaleQuestion(
+          question: question,
+          answer: answer is int ? answer as int : question.scaleMin,
+          onChanged: (value) => onChanged(value),
+        );
+      case SurveyQuestionType.checkbox:
+        final selectedValues = <String>{};
+        if (answer is Iterable) {
+          for (final item in answer as Iterable<dynamic>) {
+            selectedValues.add(item.toString());
+          }
+        }
+        return Column(
+          children: [
+            for (final option in question.options)
+              CheckboxListTile(
+                value: selectedValues.contains(option.value),
+                title: Text(option.label),
+                onChanged: (isChecked) {
+                  final updated = <String>{...selectedValues};
+                  if (isChecked ?? false) {
+                    updated.add(option.value);
+                  } else {
+                    updated.remove(option.value);
+                  }
+                  onChanged(updated.toList());
+                },
+              ),
+          ],
+        );
+      case SurveyQuestionType.radio:
+        final selected = answer?.toString();
+        return Column(
+          children: [
+            for (final option in question.options)
+              RadioListTile<String>(
+                value: option.value,
+                groupValue: selected,
+                title: Text(option.label),
+                onChanged: (value) {
+                  if (value != null) {
+                    onChanged(value);
+                  }
+                },
+              ),
+          ],
+        );
+      case SurveyQuestionType.text:
+        return TextFormField(
+          key: ValueKey(question.id),
+          initialValue: answer is String ? answer as String : '',
+          minLines: 3,
+          maxLines: 5,
+          decoration: const InputDecoration(
+            border: OutlineInputBorder(),
+          ),
+          onChanged: onChanged,
+        );
+    }
+  }
+}
+
+class _ScaleQuestion extends StatefulWidget {
+  const _ScaleQuestion({
+    required this.question,
+    required this.answer,
+    required this.onChanged,
+  });
+
+  final SurveyQuestionModel question;
+  final int answer;
+  final ValueChanged<int> onChanged;
+
+  @override
+  State<_ScaleQuestion> createState() => _ScaleQuestionState();
+}
+
+class _ScaleQuestionState extends State<_ScaleQuestion> {
+  late double _value;
+
+  @override
+  void initState() {
+    super.initState();
+    _value = widget.answer.toDouble();
+  }
+
+  @override
+  void didUpdateWidget(covariant _ScaleQuestion oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.answer != widget.answer) {
+      _value = widget.answer.toDouble();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final min = widget.question.scaleMin.toDouble();
+    final max = widget.question.scaleMax.toDouble();
+    final divisions = (max - min).toInt();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Slider(
+          value: _value.clamp(min, max),
+          min: min,
+          max: max,
+          divisions: divisions > 0 ? divisions : null,
+          label: _value.round().toString(),
+          onChanged: (value) {
+            setState(() {
+              _value = value;
+            });
+            widget.onChanged(value.round());
+          },
+        ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(min.toInt().toString()),
+            Text(max.toInt().toString()),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/test/survey/survey_page_test.dart
+++ b/test/survey/survey_page_test.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:tochka_rosta/core/localization/l10n.dart';
+import 'package:tochka_rosta/features/survey/data/models/survey_models.dart';
+import 'package:tochka_rosta/features/survey/domain/survey_repository.dart';
+import 'package:tochka_rosta/features/survey/presentation/controllers/survey_controller.dart';
+import 'package:tochka_rosta/features/survey/presentation/controllers/survey_sync_service.dart';
+import 'package:tochka_rosta/features/survey/presentation/pages/survey_page.dart';
+
+class FakeSurveyRepository implements SurveyRepository {
+  FakeSurveyRepository(this._survey);
+
+  final SurveyVersionModel _survey;
+  final Map<String, dynamic> savedAnswers = {};
+
+  @override
+  Future<SurveyVersionModel> fetchActiveSurvey({bool forceRefresh = false}) async {
+    return _survey;
+  }
+
+  @override
+  Future<Map<String, dynamic>> loadSavedAnswers(
+    String surveyVersionId,
+    String userId,
+  ) async {
+    return Map<String, dynamic>.from(savedAnswers);
+  }
+
+  @override
+  Future<void> saveAnswer({
+    required String surveyVersionId,
+    required String questionId,
+    required String userId,
+    required dynamic answer,
+    DateTime? answeredAt,
+  }) async {
+    savedAnswers[questionId] = answer;
+  }
+
+  @override
+  Future<List<SurveyAnswerPayload>> pendingAnswers(String userId) async => [];
+
+  @override
+  Future<void> markAnswerSynced(String responseId) async {}
+
+  @override
+  Future<SurveyProgressModel> getProgress(
+    String surveyVersionId,
+    String userId,
+  ) async {
+    return SurveyProgressModel(
+      totalQuestions: _survey.sections.fold<int>(
+        0,
+        (previousValue, element) => previousValue + element.questions.length,
+      ),
+      answeredQuestions: savedAnswers.length,
+    );
+  }
+}
+
+SurveyVersionModel _buildSurvey(SurveyQuestionModel question) {
+  return SurveyVersionModel(
+    id: 'survey',
+    versionNumber: 1,
+    title: 'Анкета',
+    isActive: true,
+    sections: [
+      SurveySectionModel(
+        id: 'section',
+        versionId: 'survey',
+        title: 'Блок 1',
+        description: 'Описание блока',
+        position: 0,
+        timeLimitSeconds: 300,
+        questions: [question],
+      ),
+    ],
+  );
+}
+
+void main() {
+  testWidgets('renders scale question and saves changes', (tester) async {
+    final question = SurveyQuestionModel(
+      id: 'q1',
+      sectionId: 'section',
+      versionId: 'survey',
+      type: SurveyQuestionType.scale,
+      text: 'Оцените от 0 до 10',
+      position: 0,
+      scaleMin: 0,
+      scaleMax: 10,
+    );
+    final repository = FakeSurveyRepository(_buildSurvey(question));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          surveyRepositoryProvider.overrideWithValue(repository),
+          surveySyncServiceProvider.overrideWithValue(null),
+          firebaseAnalyticsProvider.overrideWithValue(null),
+          surveyUserIdProvider.overrideWithValue('tester'),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const SurveyPage(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Slider), findsOneWidget);
+    await tester.drag(find.byType(Slider), const Offset(200, 0));
+    await tester.pumpAndSettle();
+
+    expect(repository.savedAnswers['q1'], isNotNull);
+  });
+
+  testWidgets('renders checkbox question and toggles options', (tester) async {
+    final question = SurveyQuestionModel(
+      id: 'q1',
+      sectionId: 'section',
+      versionId: 'survey',
+      type: SurveyQuestionType.checkbox,
+      text: 'Выберите варианты',
+      position: 0,
+      options: const [
+        SurveyOptionModel(id: 'o1', value: 'o1', label: 'Первый', position: 0),
+        SurveyOptionModel(id: 'o2', value: 'o2', label: 'Второй', position: 1),
+      ],
+    );
+    final repository = FakeSurveyRepository(_buildSurvey(question));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          surveyRepositoryProvider.overrideWithValue(repository),
+          surveySyncServiceProvider.overrideWithValue(null),
+          firebaseAnalyticsProvider.overrideWithValue(null),
+          surveyUserIdProvider.overrideWithValue('tester'),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const SurveyPage(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Первый'));
+    await tester.pumpAndSettle();
+
+    expect(repository.savedAnswers['q1'], contains('o1'));
+  });
+
+  testWidgets('shows validation error for required question', (tester) async {
+    final question = SurveyQuestionModel(
+      id: 'q1',
+      sectionId: 'section',
+      versionId: 'survey',
+      type: SurveyQuestionType.text,
+      text: 'Расскажите о себе',
+      isRequired: true,
+      position: 0,
+    );
+    final repository = FakeSurveyRepository(_buildSurvey(question));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          surveyRepositoryProvider.overrideWithValue(repository),
+          surveySyncServiceProvider.overrideWithValue(null),
+          firebaseAnalyticsProvider.overrideWithValue(null),
+          surveyUserIdProvider.overrideWithValue('tester'),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const SurveyPage(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Далее'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Пожалуйста, ответьте на вопрос.'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- implement survey models, repository, and sync service with offline caching and analytics hooks
- build the dynamic survey page with timers, auto-save navigation, and question-type widgets
- add widget coverage for rendering various question types and required-field validation

## Testing
- flutter test *(fails: flutter binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d533b1cefc8329ad0ab9016539f928