### PR TITLE
feat: add results report list and detail screens

### DIFF
--- a/assets/translations/intl_en.arb
+++ b/assets/translations/intl_en.arb
@@ -22,5 +22,22 @@
   "chatSend": "Send",
   "chatAuthorModerator": "Moderator",
   "chatAuthorUser": "Participant",
-  "chatMessagePending": "sending"
+  "chatMessagePending": "sending",
+  "resultsEmptyState": "No reports available yet.",
+  "resultsStatusInReview": "In review",
+  "resultsStatusReady": "Ready",
+  "resultsCreatedAt": "Created:",
+  "resultsUpdatedAt": "Updated:",
+  "resultsSummaryTitle": "Summary",
+  "resultsRecommendationsTitle": "Recommendations",
+  "resultsRecommendationsEmpty": "No recommendations yet.",
+  "resultsExportCsv": "Export CSV",
+  "resultsDownloadPdf": "Download PDF",
+  "resultsModeratorSectionTitle": "Moderator tools",
+  "resultsSummaryEditorHint": "Adjust the key metrics before publishing. Changes are kept locally until you publish.",
+  "resultsSummaryDraftNotice": "Changes are not published yet.",
+  "resultsPublishAction": "Publish",
+  "resultsPublishSuccessMessage": "Summary saved and ready for publication.",
+  "resultsExportPreparing": "Preparing export",
+  "resultsNotFoundMessage": "Report not found."
 }

--- a/assets/translations/intl_ru.arb
+++ b/assets/translations/intl_ru.arb
@@ -22,5 +22,22 @@
   "chatSend": "Отправить",
   "chatAuthorModerator": "Модератор",
   "chatAuthorUser": "Участник",
-  "chatMessagePending": "отправляется"
+  "chatMessagePending": "отправляется",
+  "resultsEmptyState": "Пока нет доступных отчетов.",
+  "resultsStatusInReview": "На проверке",
+  "resultsStatusReady": "Готов",
+  "resultsCreatedAt": "Создан:",
+  "resultsUpdatedAt": "Обновлен:",
+  "resultsSummaryTitle": "Сводка",
+  "resultsRecommendationsTitle": "Рекомендации",
+  "resultsRecommendationsEmpty": "Рекомендаций пока нет.",
+  "resultsExportCsv": "Экспорт CSV",
+  "resultsDownloadPdf": "Скачать PDF",
+  "resultsModeratorSectionTitle": "Модерация summary",
+  "resultsSummaryEditorHint": "Отредактируйте ключевые показатели перед публикацией. Значения сохраняются локально до публикации.",
+  "resultsSummaryDraftNotice": "Изменения еще не опубликованы.",
+  "resultsPublishAction": "Опубликовать",
+  "resultsPublishSuccessMessage": "Summary сохранено и готово к публикации.",
+  "resultsExportPreparing": "Подготовка выгрузки",
+  "resultsNotFoundMessage": "Отчет не найден."
 }

--- a/lib/core/localization/l10n.dart
+++ b/lib/core/localization/l10n.dart
@@ -84,6 +84,23 @@ class AppLocalizations {
   String get chatAuthorModerator => _get('chatAuthorModerator');
   String get chatAuthorUser => _get('chatAuthorUser');
   String get chatMessagePending => _get('chatMessagePending');
+  String get resultsEmptyState => _get('resultsEmptyState');
+  String get resultsStatusInReview => _get('resultsStatusInReview');
+  String get resultsStatusReady => _get('resultsStatusReady');
+  String get resultsCreatedAt => _get('resultsCreatedAt');
+  String get resultsUpdatedAt => _get('resultsUpdatedAt');
+  String get resultsSummaryTitle => _get('resultsSummaryTitle');
+  String get resultsRecommendationsTitle => _get('resultsRecommendationsTitle');
+  String get resultsRecommendationsEmpty => _get('resultsRecommendationsEmpty');
+  String get resultsExportCsv => _get('resultsExportCsv');
+  String get resultsDownloadPdf => _get('resultsDownloadPdf');
+  String get resultsModeratorSectionTitle => _get('resultsModeratorSectionTitle');
+  String get resultsSummaryEditorHint => _get('resultsSummaryEditorHint');
+  String get resultsSummaryDraftNotice => _get('resultsSummaryDraftNotice');
+  String get resultsPublishAction => _get('resultsPublishAction');
+  String get resultsPublishSuccessMessage => _get('resultsPublishSuccessMessage');
+  String get resultsExportPreparing => _get('resultsExportPreparing');
+  String get resultsNotFoundMessage => _get('resultsNotFoundMessage');
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -8,6 +8,8 @@ import '../../features/chat/presentation/pages/chat_page.dart';
 import '../../features/home/presentation/pages/home_page.dart';
 import '../../features/onboarding/presentation/pages/onboarding_page.dart';
 import '../../features/profile/presentation/pages/profile_page.dart';
+import '../../features/results/presentation/models/report_models.dart';
+import '../../features/results/presentation/pages/report_view_page.dart';
 import '../../features/results/presentation/pages/results_page.dart';
 import '../../features/settings/presentation/pages/settings_page.dart';
 import '../../features/survey/presentation/pages/survey_page.dart';
@@ -53,6 +55,19 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                 path: ResultsPage.routePath,
                 name: ResultsPage.routeName,
                 builder: (context, state) => const ResultsPage(),
+                routes: [
+                  GoRoute(
+                    path: ReportViewPage.routePath,
+                    name: ReportViewPage.routeName,
+                    builder: (context, state) {
+                      final extra = state.extra;
+                      if (extra is Report) {
+                        return ReportViewPage(report: extra);
+                      }
+                      return const _ReportNotFoundPage();
+                    },
+                  ),
+                ],
               ),
             ],
           ),
@@ -107,6 +122,21 @@ class AppShell extends StatelessWidget {
           NavigationDestination(icon: const Icon(Icons.chat_bubble_outline), label: l10n.chatTitle),
           NavigationDestination(icon: const Icon(Icons.person_outline), label: l10n.profileTitle),
         ],
+      ),
+    );
+  }
+}
+
+class _ReportNotFoundPage extends StatelessWidget {
+  const _ReportNotFoundPage();
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.resultsTitle)),
+      body: Center(
+        child: Text(l10n.resultsNotFoundMessage),
       ),
     );
   }

--- a/lib/features/results/presentation/models/report_models.dart
+++ b/lib/features/results/presentation/models/report_models.dart
@@ -1,0 +1,75 @@
+import 'package:equatable/equatable.dart';
+
+enum ReportStatus {
+  inReview('in_review'),
+  ready('ready');
+
+  const ReportStatus(this.apiValue);
+
+  final String apiValue;
+
+  static ReportStatus fromApi(String value) {
+    return ReportStatus.values.firstWhere(
+      (status) => status.apiValue == value,
+      orElse: () => ReportStatus.inReview,
+    );
+  }
+}
+
+class ReportRecommendation extends Equatable {
+  const ReportRecommendation({
+    required this.id,
+    required this.title,
+    required this.description,
+  });
+
+  final String id;
+  final String title;
+  final String description;
+
+  @override
+  List<Object?> get props => [id, title, description];
+}
+
+class Report extends Equatable {
+  const Report({
+    required this.id,
+    required this.title,
+    required this.subtitle,
+    required this.status,
+    required this.summary,
+    required this.recommendations,
+    required this.createdAt,
+    this.updatedAt,
+  });
+
+  final String id;
+  final String title;
+  final String subtitle;
+  final ReportStatus status;
+  final Map<String, dynamic> summary;
+  final List<ReportRecommendation> recommendations;
+  final DateTime createdAt;
+  final DateTime? updatedAt;
+
+  Report copyWith({
+    ReportStatus? status,
+    Map<String, dynamic>? summary,
+    List<ReportRecommendation>? recommendations,
+    DateTime? updatedAt,
+  }) {
+    return Report(
+      id: id,
+      title: title,
+      subtitle: subtitle,
+      status: status ?? this.status,
+      summary: summary ?? this.summary,
+      recommendations: recommendations ?? this.recommendations,
+      createdAt: createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  @override
+  List<Object?> get props => [id, title, subtitle, status, summary, recommendations, createdAt, updatedAt];
+}

--- a/lib/features/results/presentation/pages/report_view_page.dart
+++ b/lib/features/results/presentation/pages/report_view_page.dart
@@ -1,0 +1,274 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/localization/l10n.dart';
+import '../../../../core/providers/app_providers.dart';
+import '../models/report_models.dart';
+
+class ReportViewPage extends ConsumerStatefulWidget {
+  const ReportViewPage({required this.report, super.key});
+
+  static const routeName = 'report-view';
+  static const routePath = ':reportId';
+
+  final Report report;
+
+  @override
+  ConsumerState<ReportViewPage> createState() => _ReportViewPageState();
+}
+
+class _ReportViewPageState extends ConsumerState<ReportViewPage> {
+  late Map<String, TextEditingController> _controllers;
+  late Map<String, dynamic> _currentSummary;
+  bool _hasChanges = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentSummary = Map<String, dynamic>.from(widget.report.summary);
+    _controllers = <String, TextEditingController>{};
+    _initControllers(widget.report.summary);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final analytics = ref.read(firebaseAnalyticsProvider);
+      analytics?.logEvent(
+        name: 'report_ready_view',
+        parameters: {
+          'report_id': widget.report.id,
+          'status': widget.report.status.apiValue,
+        },
+      );
+    });
+  }
+
+  @override
+  void dispose() {
+    for (final controller in _controllers.values) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final isModeratorView = widget.report.status == ReportStatus.inReview;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.report.title),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text(
+            widget.report.subtitle,
+            style: theme.textTheme.titleMedium,
+          ),
+          const SizedBox(height: 16),
+          Wrap(
+            spacing: 12,
+            runSpacing: 8,
+            children: [
+              OutlinedButton.icon(
+                icon: const Icon(Icons.table_view),
+                onPressed: () => _onExport(context, 'csv'),
+                label: Text(l10n.resultsExportCsv),
+              ),
+              OutlinedButton.icon(
+                icon: const Icon(Icons.picture_as_pdf_outlined),
+                onPressed: () => _onExport(context, 'pdf'),
+                label: Text(l10n.resultsDownloadPdf),
+              ),
+            ],
+          ),
+          const SizedBox(height: 24),
+          Text(
+            l10n.resultsSummaryTitle,
+            style: theme.textTheme.titleMedium,
+          ),
+          const SizedBox(height: 12),
+          ..._buildSummaryBlocks(context, _currentSummary),
+          const SizedBox(height: 24),
+          Text(
+            l10n.resultsRecommendationsTitle,
+            style: theme.textTheme.titleMedium,
+          ),
+          const SizedBox(height: 12),
+          if (widget.report.recommendations.isEmpty)
+            Text(l10n.resultsRecommendationsEmpty)
+          else
+            ...widget.report.recommendations.map(
+              (recommendation) => Card(
+                child: ListTile(
+                  leading: const Icon(Icons.lightbulb_outline),
+                  title: Text(recommendation.title),
+                  subtitle: Text(recommendation.description),
+                ),
+              ),
+            ),
+          if (isModeratorView) ...[
+            const SizedBox(height: 32),
+            Divider(color: theme.colorScheme.outlineVariant),
+            const SizedBox(height: 16),
+            Text(
+              l10n.resultsModeratorSectionTitle,
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              l10n.resultsSummaryEditorHint,
+              style: theme.textTheme.bodySmall,
+            ),
+            const SizedBox(height: 16),
+            ..._controllers.entries.map((entry) {
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: TextField(
+                  controller: entry.value,
+                  decoration: InputDecoration(
+                    labelText: entry.key,
+                    border: const OutlineInputBorder(),
+                  ),
+                  maxLines: 3,
+                ),
+              );
+            }),
+            if (_hasChanges)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: Text(
+                  l10n.resultsSummaryDraftNotice,
+                  style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.primary),
+                ),
+              ),
+            ElevatedButton.icon(
+              icon: const Icon(Icons.publish_outlined),
+              onPressed: _onPublish,
+              label: Text(l10n.resultsPublishAction),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  void _initControllers(Map<String, dynamic> data, [String prefix = '']) {
+    data.forEach((key, value) {
+      final path = prefix.isEmpty ? key : '$prefix.$key';
+      if (value is Map<String, dynamic>) {
+        _initControllers(value, path);
+      } else {
+        final controller = TextEditingController(text: value.toString());
+        controller.addListener(() {
+          setState(() {
+            _hasChanges = true;
+          });
+        });
+        _controllers[path] = controller;
+      }
+    });
+  }
+
+  List<Widget> _buildSummaryBlocks(BuildContext context, Map<String, dynamic> summary) {
+    final theme = Theme.of(context);
+    return summary.entries.map((entry) {
+      final value = entry.value;
+      if (value is Map<String, dynamic>) {
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  entry.key,
+                  style: theme.textTheme.titleSmall,
+                ),
+                const SizedBox(height: 8),
+                ...value.entries.map(
+                  (metric) => Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Expanded(
+                          flex: 2,
+                          child: Text(
+                            metric.key,
+                            style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          flex: 3,
+                          child: Text(
+                            metric.value.toString(),
+                            style: theme.textTheme.bodyMedium,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      }
+      return Card(
+        child: ListTile(
+          title: Text(entry.key),
+          subtitle: Text(value.toString()),
+        ),
+      );
+    }).toList();
+  }
+
+  Map<String, dynamic> _collectUpdatedSummary(Map<String, dynamic> source, [String prefix = '']) {
+    final result = <String, dynamic>{};
+    source.forEach((key, value) {
+      final path = prefix.isEmpty ? key : '$prefix.$key';
+      if (value is Map<String, dynamic>) {
+        result[key] = _collectUpdatedSummary(value, path);
+      } else {
+        final controller = _controllers[path];
+        if (controller != null) {
+          final text = controller.text.trim();
+          final numeric = num.tryParse(text);
+          result[key] = numeric ?? text;
+        } else {
+          result[key] = value;
+        }
+      }
+    });
+    return result;
+  }
+
+  void _onPublish() {
+    final l10n = AppLocalizations.of(context);
+    final updatedSummary = _collectUpdatedSummary(widget.report.summary);
+    setState(() {
+      _currentSummary = updatedSummary;
+      _hasChanges = false;
+    });
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(l10n.resultsPublishSuccessMessage)),
+    );
+  }
+
+  void _onExport(BuildContext context, String format) {
+    final l10n = AppLocalizations.of(context);
+    final analytics = ref.read(firebaseAnalyticsProvider);
+    analytics?.logEvent(
+      name: 'export_downloaded',
+      parameters: {
+        'report_id': widget.report.id,
+        'format': format,
+      },
+    );
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('${l10n.resultsExportPreparing} ${format.toUpperCase()}')),
+    );
+  }
+}

--- a/lib/features/results/presentation/pages/results_page.dart
+++ b/lib/features/results/presentation/pages/results_page.dart
@@ -1,21 +1,124 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
 
 import '../../../../core/localization/l10n.dart';
+import '../../../../core/providers/app_providers.dart';
+import '../models/report_models.dart';
+import '../providers/results_providers.dart';
+import 'report_view_page.dart';
 
-class ResultsPage extends StatelessWidget {
+class ResultsPage extends ConsumerWidget {
   const ResultsPage({super.key});
 
   static const routeName = 'results';
   static const routePath = '/results';
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
+    final reports = ref.watch(resultsReportsProvider);
+    final formatter = DateFormat.yMMMMd(l10n.locale.languageCode);
+
     return Scaffold(
       appBar: AppBar(title: Text(l10n.resultsTitle)),
-      body: const Center(
-        child: Text('Аналитика по результатам будет представлена здесь.'),
-      ),
+      body: reports.isEmpty
+          ? Center(child: Text(l10n.resultsEmptyState))
+          : ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemBuilder: (context, index) {
+                final report = reports[index];
+                final statusLabel = _statusLabel(l10n, report.status);
+                final chipColor = _statusColor(context, report.status);
+                final createdText = '${l10n.resultsCreatedAt} ${formatter.format(report.createdAt)}';
+                final updatedText = report.updatedAt == null
+                    ? null
+                    : '${l10n.resultsUpdatedAt} ${formatter.format(report.updatedAt!)}';
+                return Card(
+                  elevation: 1,
+                  clipBehavior: Clip.antiAlias,
+                  child: InkWell(
+                    onTap: () {
+                      final analytics = ref.read(firebaseAnalyticsProvider);
+                      analytics?.logEvent(
+                        name: 'report_requested',
+                        parameters: {
+                          'report_id': report.id,
+                          'status': report.status.apiValue,
+                        },
+                      );
+                      context.pushNamed(
+                        ReportViewPage.routeName,
+                        pathParameters: {'reportId': report.id},
+                        extra: report,
+                      );
+                    },
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  report.title,
+                                  style: Theme.of(context).textTheme.titleMedium,
+                                ),
+                              ),
+                              const SizedBox(width: 12),
+                              Chip(
+                                label: Text(statusLabel),
+                                backgroundColor: chipColor,
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            report.subtitle,
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
+                          const SizedBox(height: 12),
+                          Text(
+                            createdText,
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
+                          if (updatedText != null) ...[
+                            const SizedBox(height: 4),
+                            Text(
+                              updatedText,
+                              style: Theme.of(context).textTheme.bodySmall,
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ),
+                );
+              },
+              separatorBuilder: (context, index) => const SizedBox(height: 12),
+              itemCount: reports.length,
+            ),
     );
+  }
+
+  String _statusLabel(AppLocalizations l10n, ReportStatus status) {
+    switch (status) {
+      case ReportStatus.inReview:
+        return l10n.resultsStatusInReview;
+      case ReportStatus.ready:
+        return l10n.resultsStatusReady;
+    }
+  }
+
+  Color _statusColor(BuildContext context, ReportStatus status) {
+    final colorScheme = Theme.of(context).colorScheme;
+    switch (status) {
+      case ReportStatus.inReview:
+        return colorScheme.secondaryContainer;
+      case ReportStatus.ready:
+        return colorScheme.primaryContainer;
+    }
   }
 }

--- a/lib/features/results/presentation/providers/results_providers.dart
+++ b/lib/features/results/presentation/providers/results_providers.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/report_models.dart';
+
+final resultsReportsProvider = Provider<List<Report>>((ref) {
+  final now = DateTime.now();
+  return [
+    Report(
+      id: 'report-2024-q1',
+      title: 'Отчет по развитию команды',
+      subtitle: 'Итоги I квартала 2024',
+      status: ReportStatus.ready,
+      summary: {
+        'engagement': {
+          'score': 78,
+          'trend': '+5% за квартал',
+          'insight': 'Команда активно вовлекается в инициативы наставников.'
+        },
+        'competencies': {
+          'leadership': 'средний уровень',
+          'communication': 'высокий уровень',
+          'innovation': 'нужны дополнительные сессии'
+        },
+      },
+      recommendations: const [
+        ReportRecommendation(
+          id: 'rec-1',
+          title: 'Провести стратегическую сессию',
+          description: 'Собрать участников в апреле для выработки плана на следующий квартал.',
+        ),
+        ReportRecommendation(
+          id: 'rec-2',
+          title: 'Усилить обмен опытом',
+          description: 'Организовать внутренние митапы раз в две недели.',
+        ),
+      ],
+      createdAt: now.subtract(const Duration(days: 15)),
+      updatedAt: now.subtract(const Duration(days: 2)),
+    ),
+    Report(
+      id: 'report-2024-q2',
+      title: 'Промежуточный срез по наставникам',
+      subtitle: 'Подготовка к публикации',
+      status: ReportStatus.inReview,
+      summary: {
+        'engagement': {
+          'score': 71,
+          'trend': '+2% за месяц',
+        },
+        'risks': {
+          'burnout': 'средний риск',
+          'retention': 'стабильно',
+        },
+      },
+      recommendations: const [
+        ReportRecommendation(
+          id: 'rec-3',
+          title: 'Запланировать индивидуальные сессии',
+          description: 'Наставникам стоит провести 1:1 с ключевыми участниками.',
+        ),
+      ],
+      createdAt: now.subtract(const Duration(days: 7)),
+    ),
+  ];
+});


### PR DESCRIPTION
## Summary
- replace the results landing page with a list of available reports and status chips
- add a detailed report view with summary blocks, recommendations, moderator editing tools, and export actions
- wire analytics events for requesting reports, viewing report details, and exporting files

## Testing
- not run (flutter not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d62f1103ac8329bf018ca389f00c6d