### PR TITLE
Add report export endpoints and coverage tests

### DIFF
--- a/tochka_rosta_api/__init__.py
+++ b/tochka_rosta_api/__init__.py
@@ -1,0 +1,1 @@
+"""Backend application package for Tochka Rosta."""

--- a/tochka_rosta_api/app/__init__.py
+++ b/tochka_rosta_api/app/__init__.py
@@ -1,3 +1,12 @@
-from .main import app
+"""Application package providing lazy access to the FastAPI app instance."""
+
+from importlib import import_module
+from typing import Any
 
 __all__ = ["app"]
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - simple attribute proxy
+    if name == "app":
+        return import_module(".main", __name__).app
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/tochka_rosta_api/app/repositories/report.py
+++ b/tochka_rosta_api/app/repositories/report.py
@@ -1,7 +1,10 @@
 from sqlalchemy import select
+from sqlalchemy.orm import selectinload
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models.report import Report
+from ..models.response import Response
+from ..models.response import ResponseAnswer
 from .base import BaseRepository
 
 
@@ -12,3 +15,17 @@ class ReportRepository(BaseRepository[Report]):
     async def list_by_user(self, user_id: int) -> list[Report]:
         result = await self.session.execute(select(Report).where(Report.user_id == user_id))
         return result.scalars().all()
+
+    async def get_with_details(self, report_id: int) -> Report | None:
+        stmt = (
+            select(Report)
+            .options(
+                selectinload(Report.user),
+                selectinload(Report.response)
+                .selectinload(Response.answers)
+                .selectinload(ResponseAnswer.question),
+            )
+            .where(Report.id == report_id)
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()

--- a/tochka_rosta_api/app/routers/reports.py
+++ b/tochka_rosta_api/app/routers/reports.py
@@ -1,4 +1,9 @@
+import csv
+from datetime import datetime
+from io import StringIO
+
 from fastapi import APIRouter, Depends, Path
+from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.database import get_session
@@ -40,3 +45,141 @@ async def update_report(
 ) -> ReportRead:
     service = ReportService(session)
     return await service.update(report_id, payload)
+
+
+def _format_question(answer) -> str:
+    if answer.question and answer.question.text:
+        return answer.question.text
+    return f"Question {answer.question_id}"
+
+
+@router.get("/{report_id}/export.csv")
+async def export_report_csv(
+    report_id: int = Path(..., ge=1),
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> Response:
+    service = ReportService(session)
+    report = await service.get_for_export(report_id, current_user)
+    answers = service.sort_answers(report)
+
+    buffer = StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(["Report", report.id])
+    writer.writerow(["Owner", report.user.email if report.user else report.user_id])
+    writer.writerow(["Summary", report.summary or ""])
+    writer.writerow(["Generated at", datetime.utcnow().isoformat()])
+    writer.writerow([])
+    writer.writerow(["Question", "Answer"])
+    for answer in answers:
+        writer.writerow([_format_question(answer), answer.answer])
+
+    headers = {"Content-Disposition": f'attachment; filename="report_{report_id}.csv"'}
+    return Response(content=buffer.getvalue(), media_type="text/csv", headers=headers)
+
+
+@router.get("/{report_id}/export.pdf")
+async def export_report_pdf(
+    report_id: int = Path(..., ge=1),
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> Response:
+    service = ReportService(session)
+    report = await service.get_for_export(report_id, current_user)
+    answers = service.sort_answers(report)
+
+    pdf_bytes = _build_pdf_document(report.summary or "", answers)
+    headers = {"Content-Disposition": f'attachment; filename="report_{report_id}.pdf"'}
+    return Response(content=pdf_bytes, media_type="application/pdf", headers=headers)
+
+
+def _wrap_text(text: str, max_chars: int = 80) -> list[str]:
+    lines: list[str] = []
+    for paragraph in text.splitlines() or [""]:
+        words = paragraph.split()
+        if not words:
+            lines.append("")
+            continue
+        current = words[0]
+        for word in words[1:]:
+            if len(current) + 1 + len(word) > max_chars:
+                lines.append(current)
+                current = word
+            else:
+                current = f"{current} {word}"
+        lines.append(current)
+    if not lines:
+        lines.append("")
+    return lines
+
+
+def _escape_pdf_text(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+
+def _build_pdf_document(summary: str, answers) -> bytes:
+    width, height = 595, 842  # A4 in points
+    y_position = height - 72
+    content_lines: list[str] = []
+
+    def add_line(text: str, font_size: int, spacing: int) -> None:
+        nonlocal y_position
+        content_lines.extend(
+            [
+                "BT",
+                f"/F1 {font_size} Tf",
+                f"1 0 0 1 72 {y_position} Tm",
+                f"({_escape_pdf_text(text)}) Tj",
+                "ET",
+            ]
+        )
+        y_position -= spacing
+
+    add_line("Tochka Rosta", 20, 26)
+    add_line(datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC"), 10, 18)
+    y_position -= 10
+    add_line("Summary", 14, 22)
+    for line in _wrap_text(summary, 90):
+        add_line(line, 12, 16)
+    y_position -= 14
+    add_line("Key Answers", 14, 22)
+    if not answers:
+        add_line("No answers provided", 12, 16)
+    else:
+        for answer in answers:
+            text = f"{_format_question(answer)}: {answer.answer}"
+            for wrapped in _wrap_text(text, 90):
+                add_line(wrapped, 12, 16)
+            y_position -= 8
+
+    content_stream = "\n".join(content_lines) + "\n"
+    content_bytes = content_stream.encode("utf-8")
+
+    buffer = bytearray()
+    buffer.extend(b"%PDF-1.4\n")
+
+    objects: list[bytes] = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+        f"<< /Length {len(content_bytes)} >>\nstream\n{content_stream}endstream".encode("utf-8"),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ]
+
+    offsets = [0]
+    for index, obj in enumerate(objects, start=1):
+        offsets.append(len(buffer))
+        buffer.extend(f"{index} 0 obj\n".encode("utf-8"))
+        buffer.extend(obj)
+        buffer.extend(b"\nendobj\n")
+
+    xref_position = len(buffer)
+    buffer.extend(f"xref\n0 {len(objects) + 1}\n".encode("utf-8"))
+    buffer.extend(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        buffer.extend(f"{offset:010d} 00000 n \n".encode("utf-8"))
+
+    buffer.extend(
+        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\nstartxref\n{xref_position}\n%%EOF".encode("utf-8")
+    )
+    return bytes(buffer)

--- a/tochka_rosta_api/tests/conftest.py
+++ b/tochka_rosta_api/tests/conftest.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+
+class FakeS3Storage:
+    def __init__(self) -> None:
+        self.bucket = "test-bucket"
+        self.uploaded: dict[str, dict[str, object]] = {}
+
+    def upload(self, data: bytes, key: str, content_type: str) -> None:
+        self.uploaded[key] = {"data": data, "content_type": content_type}
+
+    def generate_presigned_url(self, key: str, expires_in: int = 3600) -> str:
+        return f"https://fake-s3/{self.bucket}/{key}?expires={expires_in}"
+
+
+@pytest.fixture()
+def storage() -> FakeS3Storage:
+    return FakeS3Storage()

--- a/tochka_rosta_api/tests/test_report_exports.py
+++ b/tochka_rosta_api/tests/test_report_exports.py
@@ -1,0 +1,122 @@
+import pytest
+from fastapi import HTTPException
+
+from tochka_rosta_api.app.routers import reports
+from tochka_rosta_api.app.services.report import ReportService
+
+
+class DummyUser:
+    def __init__(self, user_id: int, email: str, role: str) -> None:
+        self.id = user_id
+        self.email = email
+        self.role = role
+
+
+class DummyQuestion:
+    def __init__(self, question_id: int, text: str, order: int) -> None:
+        self.id = question_id
+        self.text = text
+        self.order = order
+
+
+class DummyAnswer:
+    def __init__(self, question_id: int, answer: str, question: DummyQuestion) -> None:
+        self.question_id = question_id
+        self.answer = answer
+        self.question = question
+
+
+class DummyResponse:
+    def __init__(self, answers: list[DummyAnswer]) -> None:
+        self.answers = answers
+
+
+class DummyReport:
+    def __init__(self, report_id: int, owner: DummyUser, summary: str, answers: list[DummyAnswer]) -> None:
+        self.id = report_id
+        self.user_id = owner.id
+        self.user = owner
+        self.summary = summary
+        self.response = DummyResponse(answers)
+
+
+class StubReportService:
+    report_map: dict[int, DummyReport] = {}
+
+    def __init__(self, session) -> None:  # pragma: no cover - unused session stub
+        self.session = session
+
+    async def get_for_export(self, report_id: int, current_user: DummyUser) -> DummyReport:
+        report = self.report_map.get(report_id)
+        if report is None:
+            raise HTTPException(status_code=404, detail="Report not found")
+        if current_user.role != "moderator" and current_user.id != report.user_id:
+            raise HTTPException(status_code=403, detail="Forbidden")
+        return report
+
+    @staticmethod
+    def sort_answers(report: DummyReport) -> list[DummyAnswer]:
+        answers = list(report.response.answers)
+        answers.sort(
+            key=lambda ans: (
+                ans.question.order if ans.question and ans.question.order is not None else ans.question_id
+            )
+        )
+        return answers
+
+
+@pytest.mark.asyncio
+async def test_export_report_csv_includes_summary_and_answers(monkeypatch: pytest.MonkeyPatch) -> None:
+    owner = DummyUser(1, "owner@example.com", "user")
+    answers = [
+        DummyAnswer(1, "Answer A", DummyQuestion(1, "Question A", 1)),
+        DummyAnswer(2, "Answer B", DummyQuestion(2, "Question B", 2)),
+    ]
+    report = DummyReport(10, owner, "Owner summary", answers)
+    StubReportService.report_map = {report.id: report}
+    monkeypatch.setattr(reports, "ReportService", StubReportService)
+
+    response = await reports.export_report_csv(report.id, owner, None)
+
+    text_body = response.body.decode()
+    assert response.headers["content-type"].startswith("text/csv")
+    assert "Owner summary" in text_body
+    assert "Question A" in text_body
+    assert "Answer B" in text_body
+
+
+@pytest.mark.asyncio
+async def test_export_report_pdf_accessible_for_moderator(monkeypatch: pytest.MonkeyPatch) -> None:
+    owner = DummyUser(2, "owner2@example.com", "user")
+    moderator = DummyUser(99, "moderator@example.com", "moderator")
+    answers = [DummyAnswer(3, "A1", DummyQuestion(3, "Q1", 1))]
+    report = DummyReport(11, owner, "Moderator view", answers)
+    StubReportService.report_map = {report.id: report}
+    monkeypatch.setattr(reports, "ReportService", StubReportService)
+
+    response = await reports.export_report_pdf(report.id, moderator, None)
+
+    assert response.headers["content-type"] == "application/pdf"
+    assert f'report_{report.id}.pdf"' in response.headers["content-disposition"]
+    assert response.body.startswith(b"%PDF")
+
+
+@pytest.mark.asyncio
+async def test_export_report_forbidden_for_other_user() -> None:
+    owner = DummyUser(3, "owner3@example.com", "user")
+    other = DummyUser(4, "other@example.com", "user")
+    answers = [DummyAnswer(5, "Secret", DummyQuestion(5, "Q", 1))]
+    report = DummyReport(12, owner, "Hidden summary", answers)
+
+    class RepoStub:
+        async def get_with_details(self, report_id: int) -> DummyReport | None:
+            return report if report_id == report.id else None
+
+    service = ReportService(session=None)
+    service.report_repo = RepoStub()  # type: ignore[assignment]
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.get_for_export(report.id, other)
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Forbidden"


### PR DESCRIPTION
## Summary
- implement /reports/{id}/export.csv and export.pdf endpoints with owner/moderator permissions
- generate PDF export content alongside CSV summaries using a lightweight renderer
- add repository/service helpers and tests for exports and file storage using in-memory stubs

## Testing
- PYTHONPATH=. pytest tochka_rosta_api/tests

------
https://chatgpt.com/codex/tasks/task_e_68d6348c24008329a06d2e5aec4e857e