### PR TITLE
Remove Firebase Messaging dependency

### DIFF
--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -1,6 +1,5 @@
 import 'package:dio/dio.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
-import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -52,6 +51,3 @@ final firebaseAnalyticsProvider = Provider<FirebaseAnalytics?>((ref) {
   return FirebaseAnalytics.instance;
 });
 
-final firebaseMessagingProvider = Provider<FirebaseMessaging>((ref) {
-  return FirebaseMessaging.instance;
-});

--- a/lib/core/push/push_notifications_service.dart
+++ b/lib/core/push/push_notifications_service.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:dio/dio.dart';
-import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -11,9 +10,8 @@ import '../../features/chat/presentation/pages/chat_page.dart';
 import '../../features/results/presentation/pages/results_page.dart';
 
 final pushNotificationsServiceProvider = Provider<PushNotificationsService>((ref) {
-  final messaging = ref.watch(firebaseMessagingProvider);
   final dio = ref.watch(dioProvider);
-  return PushNotificationsService(ref, messaging, dio);
+  return PushNotificationsService(ref, dio);
 });
 
 final pushNotificationsInitializerProvider = FutureProvider<void>((ref) async {
@@ -22,59 +20,26 @@ final pushNotificationsInitializerProvider = FutureProvider<void>((ref) async {
 });
 
 class PushNotificationsService {
-  PushNotificationsService(this.ref, this._messaging, this._dio);
+  PushNotificationsService(this.ref, this._dio);
 
   final Ref ref;
-  final FirebaseMessaging _messaging;
   final Dio _dio;
 
   bool _initialized = false;
-  StreamSubscription<String>? _tokenSubscription;
-  StreamSubscription<RemoteMessage>? _messageSubscription;
-  StreamSubscription<RemoteMessage>? _messageOpenedSubscription;
 
   Future<void> initialize() async {
     if (_initialized) {
       return;
     }
 
-    final settings = await _messaging.requestPermission();
-    if (settings.authorizationStatus == AuthorizationStatus.denied) {
-      debugPrint('Push notifications permission denied');
-      _initialized = true;
-      return;
-    }
-
-    await _messaging.setForegroundNotificationPresentationOptions(
-      alert: true,
-      badge: true,
-      sound: true,
+    debugPrint(
+      'Push notifications are disabled because Firebase Cloud Messaging is not available.',
     );
-
-    await _registerCurrentToken();
-    _tokenSubscription = _messaging.onTokenRefresh.listen(_registerToken);
-
-    _messageSubscription = FirebaseMessaging.onMessage.listen(_handleForegroundMessage);
-    _messageOpenedSubscription =
-        FirebaseMessaging.onMessageOpenedApp.listen((message) => _handleMessage(message, fromInteraction: true));
-
-    final initialMessage = await _messaging.getInitialMessage();
-    if (initialMessage != null) {
-      _handleMessage(initialMessage, fromInteraction: true);
-    }
-
     _initialized = true;
     ref.onDispose(_dispose);
   }
 
-  Future<void> _registerCurrentToken() async {
-    final token = await _messaging.getToken();
-    if (token != null) {
-      await _registerToken(token);
-    }
-  }
-
-  Future<void> _registerToken(String token) async {
+  Future<void> registerToken(String token) async {
     try {
       await _dio.post<dynamic>(
         '/push/register',
@@ -85,14 +50,13 @@ class PushNotificationsService {
     }
   }
 
-  void _handleForegroundMessage(RemoteMessage message) {
+  void handleForegroundMessage(Map<String, dynamic> message) {
     final action = _mapMessageToAction(message);
     if (action == null) {
       return;
     }
 
     if (action.destination == _PushDestination.chat && action.chatId != null) {
-      // Ensure chat data is up-to-date when a new message arrives.
       try {
         ref.read(chatControllerProvider.notifier).selectChat(action.chatId!);
       } catch (error, stackTrace) {
@@ -101,9 +65,9 @@ class PushNotificationsService {
     }
   }
 
-  void _handleMessage(RemoteMessage message, {required bool fromInteraction}) {
+  void handleMessageInteraction(Map<String, dynamic> message) {
     final action = _mapMessageToAction(message);
-    if (action == null || !fromInteraction) {
+    if (action == null) {
       return;
     }
 
@@ -115,6 +79,85 @@ class PushNotificationsService {
         _openChat(action.chatId);
         break;
     }
+  }
+
+  _PushNotificationAction? _mapMessageToAction(Map<String, dynamic> message) {
+    final data = _extractData(message);
+    final type = (data['type'] ?? data['event'])?.toString().toLowerCase();
+    final deeplink = data['deeplink']?.toString().toLowerCase();
+    final chatId = data['chatId']?.toString() ?? data['chat_id']?.toString();
+
+    if (deeplink != null) {
+      final destination = _mapDeeplink(deeplink);
+      if (destination != null) {
+        return _PushNotificationAction(destination: destination, chatId: chatId);
+      }
+    }
+
+    final notificationTitle = data['notification_title']?.toString().toLowerCase();
+    final effectiveType = type ?? notificationTitle;
+
+    if (effectiveType == null) {
+      return null;
+    }
+
+    if (effectiveType.contains('report_ready') || effectiveType.contains('отчет готов')) {
+      return const _PushNotificationAction(destination: _PushDestination.results);
+    }
+    if (effectiveType.contains('new_message') || effectiveType.contains('новое сообщение')) {
+      return _PushNotificationAction(destination: _PushDestination.chat, chatId: chatId);
+    }
+
+    return null;
+  }
+
+  Map<String, dynamic> _extractData(Map<String, dynamic> message) {
+    final normalized = <String, dynamic>{};
+
+    void merge(Map<dynamic, dynamic>? source) {
+      if (source == null) {
+        return;
+      }
+      for (final entry in source.entries) {
+        normalized[entry.key.toString()] = entry.value;
+      }
+    }
+
+    merge(message);
+    final data = message['data'];
+    if (data is Map<dynamic, dynamic>) {
+      merge(data);
+    }
+    final notification = message['notification'];
+    if (notification is Map<dynamic, dynamic>) {
+      merge(notification);
+      if (notification['title'] != null) {
+        normalized['notification_title'] = notification['title'];
+      }
+    }
+
+    return normalized;
+  }
+
+  _PushDestination? _mapDeeplink(String deeplink) {
+    final normalized = deeplink.trim();
+    if (normalized.isEmpty) {
+      return null;
+    }
+
+    if (normalized == ResultsPage.routePath ||
+        normalized == ResultsPage.routeName ||
+        normalized.contains('results')) {
+      return _PushDestination.results;
+    }
+
+    if (normalized == ChatPage.routePath ||
+        normalized == ChatPage.routeName ||
+        normalized.contains('chat')) {
+      return _PushDestination.chat;
+    }
+
+    return null;
   }
 
   void _openResults() {
@@ -136,55 +179,7 @@ class PushNotificationsService {
     }
   }
 
-  _PushNotificationAction? _mapMessageToAction(RemoteMessage message) {
-    final data = message.data;
-    final type = (data['type'] ?? data['event'] ?? message.notification?.title)?.toString().toLowerCase();
-    final deeplink = data['deeplink']?.toString().toLowerCase();
-    final chatId = data['chatId']?.toString() ?? data['chat_id']?.toString();
-
-    if (deeplink != null) {
-      final destination = _mapDeeplink(deeplink);
-      if (destination != null) {
-        return _PushNotificationAction(destination: destination, chatId: chatId);
-      }
-    }
-
-    if (type == null) {
-      return null;
-    }
-
-    if (type.contains('report_ready') || type.contains('отчет готов')) {
-      return const _PushNotificationAction(destination: _PushDestination.results);
-    }
-    if (type.contains('new_message') || type.contains('новое сообщение')) {
-      return _PushNotificationAction(destination: _PushDestination.chat, chatId: chatId);
-    }
-
-    return null;
-  }
-
-  _PushDestination? _mapDeeplink(String deeplink) {
-    final normalized = deeplink.trim();
-    if (normalized.isEmpty) {
-      return null;
-    }
-
-    if (normalized == ResultsPage.routePath || normalized == ResultsPage.routeName || normalized.contains('results')) {
-      return _PushDestination.results;
-    }
-
-    if (normalized == ChatPage.routePath || normalized == ChatPage.routeName || normalized.contains('chat')) {
-      return _PushDestination.chat;
-    }
-
-    return null;
-  }
-
-  void _dispose() {
-    _tokenSubscription?.cancel();
-    _messageSubscription?.cancel();
-    _messageOpenedSubscription?.cancel();
-  }
+  void _dispose() {}
 }
 
 enum _PushDestination { results, chat }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:firebase_core/firebase_core.dart';
-import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -9,15 +8,9 @@ import 'core/router/app_router.dart';
 import 'core/theme/app_theme.dart';
 import 'core/push/push_notifications_service.dart';
 
-@pragma('vm:entry-point')
-Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  await Firebase.initializeApp();
-}
-
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp();
-  FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
   runApp(const ProviderScope(child: TochkaRostaApp()));
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,6 @@ dependencies:
   http_parser: ^4.0.2
   firebase_core: ^2.24.2
   firebase_analytics: ^10.7.2
-  firebase_messaging: ^14.7.5
   freezed_annotation: ^2.4.1
   json_annotation: ^4.8.1
 


### PR DESCRIPTION
## Summary
- remove the firebase_messaging package from the project dependencies and providers
- refactor the push notifications service to operate without Firebase Messaging while preserving navigation helpers
- simplify application bootstrap by dropping Firebase Messaging background handler setup

## Testing
- flutter pub get *(fails: flutter not installed in container)*
- dart format lib/main.dart lib/core/push/push_notifications_service.dart lib/core/providers/app_providers.dart *(fails: dart not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d666101a8483298cf39f7c32f08bd4