### PR TITLE
Fix workflow shell declaration

### DIFF
--- a/.github/workflows/flutter-web.yml
+++ b/.github/workflows/flutter-web.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Fail if firebase_messaging dependency is present
-        shell: /bin/bash
+        shell: bash
         run: |
           if grep -q "firebase_messaging" pubspec.yaml 2>/dev/null; then
             echo "::error::firebase_messaging package is not supported on Web."


### PR DESCRIPTION
## Summary
- update the firebase_messaging dependency check step to use the built-in `bash` shell so the workflow parses correctly

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d66b1d73448329ac2ce719fea9cfbd