### PR TITLE
Remove unsupported web renderer flag from workflow

### DIFF
--- a/.github/workflows/flutter-web.yml
+++ b/.github/workflows/flutter-web.yml
@@ -52,7 +52,7 @@ jobs:
         run: flutter create . --platforms web
 
       - name: Build Flutter web app
-        run: flutter build web --release --base-href "/${REPO_NAME}/" --web-renderer html
+        run: flutter build web --release --base-href "/${REPO_NAME}/"
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
## Summary
- update the Flutter web build command in the CI workflow to avoid using the unsupported --web-renderer flag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d66d4c96d48329ae16464a3a14206d