### PR TITLE
Fix base href placeholder in Flutter web index

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ru">
   <head>
-    <base href="/">
+    <base href="$FLUTTER_BASE_HREF">
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## Summary
- replace the hard-coded base href with the FLUTTER_BASE_HREF placeholder in web/index.html to support Flutter web builds with custom base paths

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d66e85038083298125fdf54ac73526