### PR TITLE
Fix drift database initialization for web builds

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -1,9 +1,6 @@
-import 'dart:io';
-
 import 'package:drift/drift.dart';
-import 'package:drift/native.dart';
-import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
+
+import 'connection/connection.dart';
 
 part 'app_database.g.dart';
 
@@ -281,7 +278,7 @@ class AuditLog extends Table {
     AuditLogDao,
   ],
 )
-static const List<String> _createIndexStatements = [
+const List<String> _createIndexStatements = [
   'CREATE INDEX IF NOT EXISTS idx_survey_sections_version_position ON survey_sections(survey_version_id, position)',
   'CREATE INDEX IF NOT EXISTS idx_questions_section_position ON questions(survey_section_id, position)',
   'CREATE INDEX IF NOT EXISTS idx_questions_version ON questions(survey_version_id)',
@@ -329,13 +326,7 @@ class AppDatabase extends _$AppDatabase {
   }
 }
 
-LazyDatabase _openConnection() {
-  return LazyDatabase(() async {
-    final dbFolder = await getApplicationDocumentsDirectory();
-    final file = File(p.join(dbFolder.path, 'tochka_rosta.db'));
-    return NativeDatabase.createInBackground(file);
-  });
-}
+QueryExecutor _openConnection() => openConnection();
 
 @DriftAccessor(tables: [Users])
 class UsersDao extends DatabaseAccessor<AppDatabase> with _$UsersDaoMixin {

--- a/lib/core/database/connection/connection.dart
+++ b/lib/core/database/connection/connection.dart
@@ -1,0 +1,5 @@
+import 'package:drift/drift.dart';
+
+import 'connection_native.dart' if (dart.library.html) 'connection_web.dart';
+
+QueryExecutor openConnection() => openConnectionImpl();

--- a/lib/core/database/connection/connection_native.dart
+++ b/lib/core/database/connection/connection_native.dart
@@ -1,0 +1,14 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+QueryExecutor openConnectionImpl() {
+  return LazyDatabase(() async {
+    final dbFolder = await getApplicationDocumentsDirectory();
+    final file = File(p.join(dbFolder.path, 'tochka_rosta.db'));
+    return NativeDatabase.createInBackground(file);
+  });
+}

--- a/lib/core/database/connection/connection_web.dart
+++ b/lib/core/database/connection/connection_web.dart
@@ -1,0 +1,6 @@
+import 'package:drift/drift.dart';
+import 'package:drift/web.dart';
+
+QueryExecutor openConnectionImpl() {
+  return WebDatabase('tochka_rosta');
+}


### PR DESCRIPTION
## Summary
- add platform-specific database connection helpers to open the Drift database on native and web
- update `AppDatabase` to use the new connection factory and fix the global index statement declaration

## Testing
- not run (Flutter SDK is not available in the environment)

------
https://chatgpt.com/codex/tasks/task_e_68d67039ee5c83298efe289af2afcdda