### PR TITLE
Fix drift compatibility and riverpod usage

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -79,7 +79,7 @@ class Questions extends Table {
   TextColumn get surveySectionId => text().references(SurveySections, #id)();
   TextColumn get surveyVersionId => text().references(SurveyVersions, #id)();
   TextColumn get questionType => text()();
-  TextColumn get text => text()();
+  TextColumn get questionText => text().named('text')();
   TextColumn get helpText => text().nullable()();
   BoolColumn get isRequired => boolean().withDefault(const Constant(false))();
   IntColumn get position => integer()();

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -2,8 +2,8 @@
 // ignore_for_file: type=lint
 part of 'app_database.dart';
 
-abstract class _\$AppDatabase extends GeneratedDatabase {
-  _\$AppDatabase(QueryExecutor e) : super(e);
+abstract class _$AppDatabase extends GeneratedDatabase {
+  _$AppDatabase(QueryExecutor e) : super(e);
 
   late final UsersTable users = UsersTable(this);
   late final ProfilesTable profiles = ProfilesTable(this);
@@ -1555,7 +1555,7 @@ class QuestionsTable extends Questions with TableInfo<QuestionsTable, Question> 
   late final GeneratedColumn<String> questionType = GeneratedColumn<String>(
       'question_type', aliasedName, false,
       type: DriftSqlType.string, requiredDuringInsert: true);
-  late final GeneratedColumn<String> text = GeneratedColumn<String>(
+  late final GeneratedColumn<String> questionText = GeneratedColumn<String>(
       'text', aliasedName, false,
       type: DriftSqlType.string, requiredDuringInsert: true);
   late final GeneratedColumn<String> helpText = GeneratedColumn<String>(
@@ -1578,7 +1578,7 @@ class QuestionsTable extends Questions with TableInfo<QuestionsTable, Question> 
         surveySectionId,
         surveyVersionId,
         questionType,
-        text,
+        questionText,
         helpText,
         isRequired,
         position,
@@ -1618,7 +1618,8 @@ class QuestionsTable extends Questions with TableInfo<QuestionsTable, Question> 
       context.missing(const VerificationMeta('questionType'));
     }
     if (data.containsKey('text')) {
-      context.handle(const VerificationMeta('text'), text.isAcceptableOrUnknown(data['text']!, const VerificationMeta('text')));
+      context.handle(const VerificationMeta('text'),
+          questionText.isAcceptableOrUnknown(data['text']!, const VerificationMeta('text')));
     } else if (isInserting) {
       context.missing(const VerificationMeta('text'));
     }

--- a/lib/features/auth/application/auth_controller.dart
+++ b/lib/features/auth/application/auth_controller.dart
@@ -129,7 +129,7 @@ class AuthController extends StateNotifier<AuthState> {
 
   Future<void> _logEvent(String name, String method, {String? error}) async {
     final analytics = ref.read(firebaseAnalyticsProvider);
-    final parameters = <String, Object?>{
+    final parameters = <String, Object>{
       'method': method,
       if (error != null && error.isNotEmpty) 'error': error,
     };

--- a/lib/features/chat/application/chat_controller.dart
+++ b/lib/features/chat/application/chat_controller.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tochka_rosta/core/database/app_database.dart';
+import 'package:tochka_rosta/core/database/repositories/messages_repository.dart';
 
 import '../../../core/providers/app_providers.dart';
 import '../data/chat_providers.dart';

--- a/lib/features/chat/presentation/pages/chat_page.dart
+++ b/lib/features/chat/presentation/pages/chat_page.dart
@@ -28,7 +28,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
   void initState() {
     super.initState();
     _scrollController.addListener(_onScroll);
-    _subscription = ref.listen<ChatState>(chatControllerProvider, (previous, next) {
+    _subscription = ref.listenManual<ChatState>(chatControllerProvider, (previous, next) {
       if (!mounted) {
         return;
       }
@@ -334,7 +334,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
           (file) => PendingAttachment(
             path: file.path!,
             name: file.name,
-            mimeType: file.mimeType,
+            mimeType: null,
             size: file.size,
           ),
         )

--- a/lib/features/survey/presentation/controllers/survey_controller.dart
+++ b/lib/features/survey/presentation/controllers/survey_controller.dart
@@ -6,6 +6,7 @@ import 'package:firebase_analytics/firebase_analytics.dart';
 import '../../../../core/providers/app_providers.dart';
 import '../../data/models/survey_models.dart';
 import '../../domain/survey_repository.dart';
+import '../../data/repositories/survey_repository_impl.dart';
 import 'survey_sync_service.dart';
 
 class SurveyState {

--- a/lib/features/survey/presentation/controllers/survey_sync_service.dart
+++ b/lib/features/survey/presentation/controllers/survey_sync_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../data/datasources/survey_remote_data_source.dart';
 import '../../data/models/survey_models.dart';
 import '../../domain/survey_repository.dart';
+import '../../data/repositories/survey_repository_impl.dart';
 
 class SurveySyncService {
   SurveySyncService(this._repository, this._remoteDataSource);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   go_router: ^12.1.0
   dio: ^5.4.0
   dio_smart_retry: ^5.0.0
-  drift: ^2.14.1
+  drift: 2.14.1
   drift_flutter: ^0.2.1
   sqlite3_flutter_libs: ^0.5.0
   path_provider: ^2.1.2
@@ -38,7 +38,7 @@ dev_dependencies:
   build_runner: ^2.4.7
   freezed: ^2.4.7
   json_serializable: ^6.7.1
-  drift_dev: ^2.14.1
+  drift_dev: 2.14.1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- pin Drift packages to 2.14.1 so the handwritten database bindings match the expected API
- repair the manual Drift bindings by removing escaped class names and renaming the question text column to avoid conflicts
- fix Riverpod listener usage, remove unsupported PlatformFile mime lookups, and add missing imports for analytics and survey providers

## Testing
- not run (environment lacks Flutter SDK)


------
https://chatgpt.com/codex/tasks/task_e_68d6795359c08329b45a9e367c8268a1