### PR TITLE
Fix Riverpod imports and drift DAO mixin

### DIFF
--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -2265,6 +2265,8 @@ class ResponsesTable extends Responses with TableInfo<ResponsesTable, Response> 
 
 mixin _$ResponsesDaoMixin on DatabaseAccessor<AppDatabase> {
   ResponsesTable get responses => attachedDatabase.responses;
+  QuestionsTable get questions => attachedDatabase.questions;
+  SurveySectionsTable get surveySections => attachedDatabase.surveySections;
 }
 
 class Report extends DataClass implements Insertable<Report> {

--- a/lib/core/network/interceptors/jwt_interceptor.dart
+++ b/lib/core/network/interceptors/jwt_interceptor.dart
@@ -1,5 +1,5 @@
 import 'package:dio/dio.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
 
 import '../../providers/app_providers.dart';
 import '../../../features/auth/application/auth_providers.dart';

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -1,7 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../database/app_database.dart';

--- a/lib/core/push/push_notifications_service.dart
+++ b/lib/core/push/push_notifications_service.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
 
 import '../providers/app_providers.dart';
 import '../router/app_router.dart';

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../localization/l10n.dart';

--- a/lib/features/auth/application/auth_controller.dart
+++ b/lib/features/auth/application/auth_controller.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
 
 import '../../../core/providers/app_providers.dart';
 import '../data/auth_repository.dart';

--- a/lib/features/auth/application/auth_providers.dart
+++ b/lib/features/auth/application/auth_providers.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
 
 import '../data/auth_repository.dart';
 import 'auth_controller.dart';

--- a/lib/features/auth/application/auth_tokens_controller.dart
+++ b/lib/features/auth/application/auth_tokens_controller.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
 
 import '../../../core/storage/secure_token_storage.dart';
 import '../domain/auth_tokens.dart';

--- a/lib/features/chat/application/chat_controller.dart
+++ b/lib/features/chat/application/chat_controller.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
 import 'package:tochka_rosta/core/database/app_database.dart';
 import 'package:tochka_rosta/core/database/repositories/messages_repository.dart';
 

--- a/lib/features/chat/data/chat_providers.dart
+++ b/lib/features/chat/data/chat_providers.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
 import 'package:tochka_rosta/core/database/app_database.dart';
 import 'package:tochka_rosta/core/database/repositories/chats_repository.dart';
 import 'package:tochka_rosta/core/database/repositories/messages_repository.dart';

--- a/lib/features/chat/data/datasources/chat_remote_data_source.dart
+++ b/lib/features/chat/data/datasources/chat_remote_data_source.dart
@@ -1,5 +1,5 @@
 import 'package:dio/dio.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
 import 'package:http_parser/http_parser.dart';
 import 'package:uuid/uuid.dart';
 

--- a/lib/features/onboarding/data/onboarding_local_datasource.dart
+++ b/lib/features/onboarding/data/onboarding_local_datasource.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
 
 class OnboardingLocalDataSource {
   const OnboardingLocalDataSource();

--- a/lib/features/onboarding/presentation/providers/onboarding_providers.dart
+++ b/lib/features/onboarding/presentation/providers/onboarding_providers.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
 
 import '../../data/onboarding_local_datasource.dart';
 import '../../domain/onboarding_repository.dart';

--- a/lib/features/results/presentation/providers/results_providers.dart
+++ b/lib/features/results/presentation/providers/results_providers.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
 
 import '../models/report_models.dart';
 

--- a/lib/features/survey/data/datasources/survey_local_data_source.dart
+++ b/lib/features/survey/data/datasources/survey_local_data_source.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 import 'package:drift/drift.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
 
 import '../../../../core/database/app_database.dart';
 import '../../../../core/providers/app_providers.dart';

--- a/lib/features/survey/data/datasources/survey_remote_data_source.dart
+++ b/lib/features/survey/data/datasources/survey_remote_data_source.dart
@@ -1,5 +1,5 @@
 import 'package:dio/dio.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
 
 import '../../../../core/providers/app_providers.dart';
 import '../models/survey_models.dart';

--- a/lib/features/survey/data/repositories/survey_repository_impl.dart
+++ b/lib/features/survey/data/repositories/survey_repository_impl.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
 
 import '../../domain/survey_repository.dart';
 import '../datasources/survey_local_data_source.dart';

--- a/lib/features/survey/presentation/controllers/survey_controller.dart
+++ b/lib/features/survey/presentation/controllers/survey_controller.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 
 import '../../../../core/providers/app_providers.dart';

--- a/lib/features/survey/presentation/controllers/survey_sync_service.dart
+++ b/lib/features/survey/presentation/controllers/survey_sync_service.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
 
 import '../../data/datasources/survey_remote_data_source.dart';
 import '../../data/models/survey_models.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,10 +12,11 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   flutter_riverpod: ^2.4.0
+  riverpod: ^2.4.0
   go_router: ^12.1.0
   dio: ^5.4.0
   dio_smart_retry: ^5.0.0
-  drift: 2.14.1
+  drift: 2.13.1
   drift_flutter: ^0.2.1
   sqlite3_flutter_libs: ^0.5.0
   path_provider: ^2.1.2
@@ -38,11 +39,11 @@ dev_dependencies:
   build_runner: ^2.4.7
   freezed: ^2.4.7
   json_serializable: ^6.7.1
-  drift_dev: 2.14.1
+  drift_dev: 2.13.1
 
 dependency_overrides:
-  drift: 2.14.1
-  drift_dev: 2.14.1
+  drift: 2.13.1
+  drift_dev: 2.13.1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- add the standalone riverpod dependency and align the drift packages with the manually maintained database bindings
- update non-UI providers and controllers to import the base riverpod library so shared logic works in pure Dart contexts
- expose the questions and surveySections tables from the ResponsesDao mixin to support the survey progress query

## Testing
- not run (environment lacks Flutter and Dart SDKs)

------
https://chatgpt.com/codex/tasks/task_e_68d681e3e70c8329a5752de4a4ae349d